### PR TITLE
feat(registry): add registerAiDriver typed wrapper

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -235,6 +235,29 @@ class Registry
     }
 
     /**
+     * Register an AI driver (chat assistant, text generation, etc).
+     *
+     * Convenience wrapper — modules call this from their ServiceProvider::boot():
+     *
+     *     Registry::registerAiDriver('my_ai_provider', [
+     *         'class'            => MyAiDriver::class,
+     *         'label'            => 'my_module::drivers.my_ai',
+     *         'website'          => 'https://my-ai.example.com',
+     *         'default_base_url' => 'https://api.my-ai.example.com/v1',
+     *         'supported_roles'  => ['chat', 'text_generation'],
+     *         'suggested_models' => [
+     *             ['value' => 'model-a', 'label' => 'Model A'],
+     *         ],
+     *     ]);
+     *
+     * @param  array<string, mixed>  $meta
+     */
+    public static function registerAiDriver(string $name, array $meta): void
+    {
+        static::registerDriver('ai', $name, $meta);
+    }
+
+    /**
      * Get all registered drivers for a given type.
      *
      * @return array<string, array<string, mixed>>  Keyed by driver name

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -260,7 +260,7 @@ class Registry
     /**
      * Get all registered drivers for a given type.
      *
-     * @return array<string, array<string, mixed>>  Keyed by driver name
+     * @return array<string, array<string, mixed>> Keyed by driver name
      */
     public static function allDrivers(string $type): array
     {

--- a/stubs/scaffold/provider.stub
+++ b/stubs/scaffold/provider.stub
@@ -116,6 +116,29 @@ class $CLASS$ extends ModuleServiceProvider
         //         ],
         //     ],
         // ]);
+
+        // -------------------------------------------------------------------
+        // Custom AI driver — uncomment if your module ships one.
+        //
+        // The driver class must extend App\Support\Ai\AiDriver and implement
+        // chatCompletion(), textCompletion(), and validateConnection(). The
+        // host's AI configuration UI will pick up `label`, `website`,
+        // `supported_roles`, `suggested_models`, and any `config_fields`.
+        //
+        // `supported_roles` tells the host which role slots this driver can
+        // fulfill. v1 roles: 'chat', 'text_generation'.
+        // -------------------------------------------------------------------
+        // ModuleRegistry::registerAiDriver('my_ai_provider', [
+        //     'class' => \Modules\\$MODULE$\\Drivers\\MyAiDriver::class,
+        //     'label' => $this->nameLower.'::drivers.my_ai',
+        //     'website' => 'https://my-ai.example.com',
+        //     'default_base_url' => 'https://api.my-ai.example.com/v1',
+        //     'supported_roles' => ['chat', 'text_generation'],
+        //     'suggested_models' => [
+        //         ['value' => 'model-a', 'label' => 'Model A'],
+        //         ['value' => 'model-b', 'label' => 'Model B'],
+        //     ],
+        // ]);
     }
 
     /**

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -301,10 +301,10 @@ class RegistryTest extends TestCase
         Registry::flushDrivers();
 
         Registry::registerExchangeRateDriver('shared_name', ['class' => 'RateDriver', 'label' => 'rate']);
-        Registry::registerAiDriver('shared_name',         ['class' => 'AiDriver',   'label' => 'ai']);
+        Registry::registerAiDriver('shared_name', ['class' => 'AiDriver',   'label' => 'ai']);
 
         $this->assertSame('RateDriver', Registry::driverMeta('exchange_rate', 'shared_name')['class']);
-        $this->assertSame('AiDriver',   Registry::driverMeta('ai',            'shared_name')['class']);
+        $this->assertSame('AiDriver', Registry::driverMeta('ai', 'shared_name')['class']);
     }
 
     public function test_all_drivers_returns_empty_array_for_unknown_type(): void

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -280,6 +280,33 @@ class RegistryTest extends TestCase
         $this->assertNotNull(Registry::driverMeta('exchange_rate', 'fake_provider'));
     }
 
+    public function test_register_ai_driver_is_a_typed_wrapper(): void
+    {
+        Registry::flushDrivers();
+
+        Registry::registerAiDriver('fake_ai_provider', [
+            'class' => 'FakeAiDriver',
+            'label' => 'fake.ai.label',
+            'supported_roles' => ['chat', 'text_generation'],
+        ]);
+
+        $meta = Registry::driverMeta('ai', 'fake_ai_provider');
+        $this->assertNotNull($meta);
+        $this->assertSame('FakeAiDriver', $meta['class']);
+        $this->assertSame(['chat', 'text_generation'], $meta['supported_roles']);
+    }
+
+    public function test_exchange_rate_and_ai_drivers_live_in_separate_type_buckets(): void
+    {
+        Registry::flushDrivers();
+
+        Registry::registerExchangeRateDriver('shared_name', ['class' => 'RateDriver', 'label' => 'rate']);
+        Registry::registerAiDriver('shared_name',         ['class' => 'AiDriver',   'label' => 'ai']);
+
+        $this->assertSame('RateDriver', Registry::driverMeta('exchange_rate', 'shared_name')['class']);
+        $this->assertSame('AiDriver',   Registry::driverMeta('ai',            'shared_name')['class']);
+    }
+
     public function test_all_drivers_returns_empty_array_for_unknown_type(): void
     {
         Registry::flushDrivers();


### PR DESCRIPTION
Adds a `registerAiDriver($name, $meta)` convenience wrapper to `Registry`, mirroring the existing `registerExchangeRateDriver()` — it simply calls `registerDriver('ai', $name, $meta)`.

**Why:** the host app (InvoiceShelf v3) registers its AI driver via `Registry::registerAiDriver(...)` in `DriverRegistryProvider`, and `AiDriverFactoryTest` calls it directly. The method was committed here previously (`dc04435`) but never pushed/released, so every published version (master + tags 3.0.0–3.0.2) lacks it — the app crashes on a clean `composer install` with `Call to undefined method …registerAiDriver()`.

Includes:
- the method on `Registry` (+ aligned phpdoc),
- the `registerAiDriver(...)` example in `stubs/scaffold/provider.stub`,
- 27 lines of `RegistryTest` coverage.

✅ `vendor/bin/phpunit` → 23 tests / 53 assertions pass; `pint --test` → pass.

**Next:** once merged, please tag a release (e.g. **3.0.3**) so the host app can pin `invoiceshelf/modules:^3.0.3` and drop its temporary generic-`registerDriver('ai', …)` workaround.
