### PR TITLE
feat: add signed module release contract

### DIFF
--- a/.github/workflows/module-release.yml
+++ b/.github/workflows/module-release.yml
@@ -1,0 +1,176 @@
+name: Module release
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: stable releases require a final SemVer; insider releases require a prerelease SemVer
+        required: true
+        type: string
+      artifact-name:
+        description: Name for the deterministic module ZIP
+        required: false
+        default: module.zip
+        type: string
+    secrets:
+      MODULE_SIGNING_SECRET_KEY_B64:
+        required: true
+      MODULE_MARKETPLACE_INGEST_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Release channel
+        required: true
+        default: stable
+        type: choice
+        options: [stable, insider]
+      artifact-name:
+        description: Name for the deterministic module ZIP
+        required: true
+        default: module.zip
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: module-release
+    env:
+      MODULE_CHANNEL: ${{ inputs.channel }}
+      MODULE_ARTIFACT_NAME: ${{ inputs['artifact-name'] || 'module.zip' }}
+      MODULE_SIGNING_KEY_ID: ${{ vars.MODULE_SIGNING_KEY_ID }}
+      MODULE_MARKETPLACE_INGEST_URL: ${{ vars.MODULE_MARKETPLACE_INGEST_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify tag matches module version
+        if: github.ref_type == 'tag'
+        run: |
+          set -euo pipefail
+          version="$(jq -er '.version | strings' module.json)"
+          if [ "$GITHUB_REF_NAME" != "$version" ]; then
+            echo "Tag '$GITHUB_REF_NAME' must exactly match module.json version '$version'." >&2
+            exit 1
+          fi
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: sodium
+          coverage: none
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install and verify source
+        run: |
+          composer install --no-interaction --prefer-dist
+          composer run lint
+          composer run test
+          if [ -f package.json ]; then
+            corepack enable
+            pnpm install --frozen-lockfile
+            pnpm run build
+          fi
+          vendor/bin/invoiceshelf-module validate-module module.json
+          vendor/bin/invoiceshelf-module validate-package .
+          jq -r '.assets[]' module.json | while IFS= read -r asset; do
+            test -f "$asset"
+          done
+
+      - name: Build deterministic artifact
+        run: |
+          set -euo pipefail
+          case "$MODULE_ARTIFACT_NAME" in
+            [A-Za-z0-9]*.zip) ;;
+            *) echo 'MODULE_ARTIFACT_NAME must be a safe basename ending in .zip.' >&2; exit 1 ;;
+          esac
+          case "$MODULE_ARTIFACT_NAME" in
+            *[!A-Za-z0-9._-]*) echo 'MODULE_ARTIFACT_NAME contains unsupported characters.' >&2; exit 1 ;;
+          esac
+          source_date_epoch="$(git log -1 --format=%ct)"
+          stage="$(mktemp -d)"
+          trap 'rm -rf "$stage"' EXIT
+          module_name="$(jq -r '.name' module.json)"
+          test "$module_name" != "null"
+          package="$stage/$module_name"
+          mkdir -p "$package"
+          git archive --format=tar HEAD | tar -xf - -C "$package"
+          if [ -d dist ]; then
+            rm -rf "$package/dist"
+            cp -a dist "$package/dist"
+          fi
+          find "$stage" -exec touch -h -d "@$source_date_epoch" {} +
+          (
+            cd "$stage"
+            find . -type f -print | LC_ALL=C sort | zip -X -q "$GITHUB_WORKSPACE/$MODULE_ARTIFACT_NAME" -@
+          )
+
+      - name: Create, validate, and sign release manifest
+        env:
+          MODULE_SIGNING_SECRET_KEY_B64: ${{ secrets.MODULE_SIGNING_SECRET_KEY_B64 }}
+        run: |
+          set -euo pipefail
+          test -n "$MODULE_SIGNING_KEY_ID"
+          slug="$(jq -r '.slug' module.json)"
+          version="$(jq -r '.version' module.json)"
+          test "$slug" != "null"
+          test "$version" != "null"
+          sha256="$(sha256sum "$MODULE_ARTIFACT_NAME" | cut -d ' ' -f 1)"
+          bytes="$(wc -c < "$MODULE_ARTIFACT_NAME" | tr -d ' ')"
+          released_at="$(date --utc +'%Y-%m-%dT%H:%M:%SZ')"
+          source_commit="$(git rev-parse HEAD)"
+          jq \
+            --arg channel "$MODULE_CHANNEL" \
+            --arg sha256 "$sha256" \
+            --argjson bytes "$bytes" \
+            --arg key_id "$MODULE_SIGNING_KEY_ID" \
+            --arg source_commit "$source_commit" \
+            --arg released_at "$released_at" \
+            '{schema_version: 1, slug, module_name: .name, version, channel: $channel, publication: "published", compatibility, artifact: {sha256: $sha256, bytes: $bytes}, key_id: $key_id, source_commit: $source_commit, released_at: $released_at}' \
+            module.json > release-manifest.json
+          vendor/bin/invoiceshelf-module validate-release release-manifest.json
+          vendor/bin/invoiceshelf-module canonicalize-release release-manifest.json > release-manifest.canonical.json
+          php -r '
+            $key = base64_decode(getenv("MODULE_SIGNING_SECRET_KEY_B64"), true);
+            if ($key === false || strlen($key) !== SODIUM_CRYPTO_SIGN_SECRETKEYBYTES) { throw new RuntimeException("MODULE_SIGNING_SECRET_KEY_B64 is not a raw Ed25519 secret key."); }
+            echo base64_encode(sodium_crypto_sign_detached(file_get_contents("release-manifest.canonical.json"), $key));
+          ' > release-manifest.sig
+
+      - name: Upload signed release to marketplace ingest
+        env:
+          MODULE_MARKETPLACE_INGEST_TOKEN: ${{ secrets.MODULE_MARKETPLACE_INGEST_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "$MODULE_MARKETPLACE_INGEST_URL"
+          slug="$(jq -r '.slug' module.json)"
+          version="$(jq -r '.version' module.json)"
+          case "$MODULE_ARTIFACT_NAME" in
+            [A-Za-z0-9]*.zip) ;;
+            *) echo 'MODULE_ARTIFACT_NAME must be a safe basename ending in .zip.' >&2; exit 1 ;;
+          esac
+          case "$MODULE_ARTIFACT_NAME" in
+            *[!A-Za-z0-9._-]*) echo 'MODULE_ARTIFACT_NAME contains unsupported characters.' >&2; exit 1 ;;
+          esac
+          case "$MODULE_MARKETPLACE_INGEST_URL" in
+            https://*) ;;
+            *) echo 'MODULE_MARKETPLACE_INGEST_URL must use HTTPS.' >&2; exit 1 ;;
+          esac
+          manifest="$(<release-manifest.json)"
+          signature="$(<release-manifest.sig)"
+          curl --fail-with-body --silent --show-error \
+            --request POST "${MODULE_MARKETPLACE_INGEST_URL%/}/$slug/releases" \
+            --header "Authorization: Bearer $MODULE_MARKETPLACE_INGEST_TOKEN" \
+            --form "repository=$GITHUB_REPOSITORY" \
+            --form "version=$version" \
+            --form "channel=$MODULE_CHANNEL" \
+            --form-string "manifest=$manifest" \
+            --form-string "signature=$signature" \
+            --form "key_id=$MODULE_SIGNING_KEY_ID" \
+            --form "artifact=@$MODULE_ARTIFACT_NAME;type=application/zip"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # InvoiceShelf Modules
 
-A thin extension package on top of [`nwidart/laravel-modules`](https://github.com/nWidart/laravel-modules) that adds an InvoiceShelf-specific registry for module-contributed sidebar entries and settings schemas.
+The MIT-licensed SDK for InvoiceShelf v3 modules. It extends [`nwidart/laravel-modules`](https://github.com/nWidart/laravel-modules) with registry helpers and the versioned, signed marketplace contract used by the secure module installer.
+
+The SDK remains MIT. Official first-party modules are separate repositories and packages, and must be licensed `AGPL-3.0-only`; the generator's `composer.json` stub defaults to that license.
 
 ## What it provides
 
@@ -10,6 +12,94 @@ A thin extension package on top of [`nwidart/laravel-modules`](https://github.co
 - **`InvoiceShelf\Modules\Settings\Schema` / `FieldType`** — a value object + enum that lock down the supported field types (`text`, `password`, `textarea`, `switch`, `number`, `select`, `multiselect`) and validate the schema shape at registration time.
 
 The actual module loading, file generation, migration, and provider registration are all handled by upstream `nwidart/laravel-modules` (required as a composer dependency).
+
+## Official module package contract
+
+An official module lives in its own repository and Composer package — never in this SDK repository or in the InvoiceShelf application repository. First-party packages use the reserved `invoiceshelf/module-<slug>` convention (the generator's Composer stub uses it automatically); this marketplace contract is for official modules, not a runtime package-install mechanism for arbitrary third-party code. `php artisan module:make` creates the extended `module.json` automatically through this SDK's [`stubs/json.stub`](stubs/json.stub).
+
+`module.json` is schema version 1. Its identity (`slug`, loader `name`) is immutable after the first marketplace release. It preserves nwidart loader keys (`name`, `alias`, `description`, `keywords`, `priority`, `providers`, `aliases`, `files`, and `requires`) and adds an exact SemVer `version`, SPDX `license`, compatibility constraints, required `ext-*` PHP extensions, module-to-module SemVer dependencies, and local compiled `dist/*.js`/`dist/*.css` assets. Unknown fields beyond those defined loader and SDK keys are rejected.
+
+```json
+{
+  "schema_version": 1,
+  "slug": "sales-tax-us",
+  "name": "SalesTaxUs",
+  "alias": "salestaxus",
+  "description": "",
+  "keywords": [],
+  "priority": 0,
+  "version": "1.2.3",
+  "license": "AGPL-3.0-only",
+  "providers": ["Modules\\SalesTaxUs\\Providers\\SalesTaxUsServiceProvider"],
+  "aliases": {},
+  "files": [],
+  "requires": {},
+  "compatibility": {
+    "invoiceshelf": "^3.0.0",
+    "module_api": "^1.0.0",
+    "php": "^8.3.0",
+    "extensions": ["ext-json"]
+  },
+  "module_dependencies": {"accounting-core": "^1.0.0"},
+  "migration_policy": "forward-only",
+  "dependency_policy": "host-provided-only",
+  "assets": ["dist/module.js", "dist/module.css"]
+}
+```
+
+The policies are deliberately closed: migrations are forward-only and installation never runs Composer, npm, pnpm, or another dependency resolver. Runtime dependencies must be provided by InvoiceShelf (`host-provided-only`). Generated packages use Orchestra Testbench 11 (Laravel 13), PHPUnit 12, and Pint only as `require-dev` CI tooling; build tooling is allowed in CI only, and compiled output is shipped inside the ZIP. Remote URLs, source assets, path traversal, arbitrary PHP providers, unsupported constraints, and unknown manifest fields are rejected.
+
+At runtime, `Registry::registerScript()` and `Registry::registerStyle()` accept only existing local `.js` and `.css` files (for example `module_path($name, 'dist/module.js')`). The registry stores the canonical real path and rejects URLs, missing files, and incorrect extensions; modules cannot inject remote scripts or styles.
+
+## Signed releases
+
+Each release has a second, immutable schema-v1 `release-manifest.json`, generated in CI. It contains the module identity/version, `channel` (`stable` or `insider`), immutable `publication: "published"`, compatibility, artifact lowercase SHA-256 and byte size, `key_id`, lowercase 40-character source commit, and RFC 3339 release time. Stable releases require a final SemVer; insider releases require a prerelease SemVer.
+
+The signature is a standard-base64 Ed25519 detached signature over the canonical JSON bytes of this manifest only. Canonical JSON recursively sorts object keys lexicographically, preserves list order, uses `JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR`, and contains no whitespace or newline. The SDK verifies signatures using public keys only; it never accepts or stores private signing keys.
+
+Marketplace responses have this envelope:
+
+```json
+{
+  "success": true,
+  "manifest": { "...": "signed release manifest" },
+  "signature": "base64 detached Ed25519 signature",
+  "key_id": "official-2026-01",
+  "artifact": {
+    "sha256": "lowercase hex SHA-256",
+    "bytes": 1234,
+    "download_url": "https://...",
+    "expires_at": "2026-08-05T12:00:00Z"
+  }
+}
+```
+
+The envelope `key_id`, artifact SHA-256, and bytes must equal their signed manifest counterparts. Current catalog state is intentionally outside the signature: an optional `release_state` (`published` or `yanked`) and required `yanked_reason` for yanked releases let the marketplace yank a release without a private key or a re-sign.
+
+Use the bundled executable in development and CI:
+
+```bash
+vendor/bin/invoiceshelf-module validate-module module.json
+vendor/bin/invoiceshelf-module validate-package .
+vendor/bin/invoiceshelf-module validate-release release-manifest.json
+vendor/bin/invoiceshelf-module canonicalize-release release-manifest.json > release-manifest.canonical.json
+vendor/bin/invoiceshelf-module generate-keypair official-2026-01
+```
+
+## Release workflow
+
+Copy or call [`.github/workflows/module-release.yml`](.github/workflows/module-release.yml) from each official module repository. When a caller invokes it from a tag, the workflow fails before secrets are used unless `GITHUB_REF_NAME` exactly equals `module.json`'s version (for example, `1.2.3`, not `v1.2.3`). Manual dispatch and branch-based `workflow_call` usage remain available. It installs dependencies, runs Pint in test mode and PHPUnit, builds frontend assets if present, validates the complete package (including built local assets and Composer host-only dependencies), makes a timestamp-normalized deterministic ZIP rooted at the module `name`, calculates SHA-256/bytes, creates and validates the release manifest, canonicalizes through the SDK CLI, then signs those exact bytes with a protected environment secret before uploading to the configured website ingest endpoint.
+
+Configure the protected `module-release` environment with:
+
+- `MODULE_SIGNING_SECRET_KEY_B64` secret: standard base64 raw Ed25519 secret key.
+- `MODULE_MARKETPLACE_INGEST_TOKEN` secret: ingest bearer token.
+- `MODULE_SIGNING_KEY_ID` variable: matching public-key identifier.
+- `MODULE_MARKETPLACE_INGEST_URL` variable: website ingest base URL ending in `/api/marketplace/v1/modules` (the workflow appends `/{slug}/releases`).
+
+No private key, token, endpoint, or organization-specific value is hardcoded in the template. The checkout disables persisted GitHub credentials; the protected, repository-scoped ingest token is used only as a masked bearer value for the single release registration request. The workflow sends the manifest and detached signature as scalar multipart fields (not upload parts), as required by the website ingest endpoint. A caller can use the workflow with `secrets: inherit`; the source repository retains the protected environment and its secrets.
+
+`generate-keypair` prints a standard-base64 Ed25519 keypair and does not write files. Put `secret_key_b64` only in the protected `MODULE_SIGNING_SECRET_KEY_B64` GitHub environment secret, put `public_key_b64` under its `key_id` in the website and InvoiceShelf public-key configuration, then discard the command output. Never commit either key.
 
 ## Usage from inside a module
 
@@ -45,4 +135,4 @@ Because `nwidart/laravel-modules` only boots providers for currently-activated m
 
 ## License
 
-MIT. See [LICENSE.md](LICENSE.md).
+This SDK is MIT. See [LICENSE.md](LICENSE.md). Official module packages generated from its stubs are `AGPL-3.0-only` by default and must include their corresponding license text and complete source needed to produce every shipped `dist/` asset.

--- a/bin/invoiceshelf-module
+++ b/bin/invoiceshelf-module
@@ -1,0 +1,55 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use InvoiceShelf\Modules\Manifest\ManifestValidator;
+use InvoiceShelf\Modules\Manifest\SigningKeyPairGenerator;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+[$command, $target] = array_pad(array_slice($argv, 1), 2, null);
+
+if (! in_array($command, ['validate-module', 'validate-package', 'validate-release', 'canonicalize-release', 'generate-keypair'], true) || ! is_string($target)) {
+    fwrite(STDERR, "Usage: invoiceshelf-module <validate-module|validate-package|validate-release|canonicalize-release> <path>\n");
+    fwrite(STDERR, "       invoiceshelf-module generate-keypair <key-id>\n");
+    exit(64);
+}
+
+try {
+    if ($command === 'generate-keypair') {
+        $keypair = SigningKeyPairGenerator::generate($target);
+        fwrite(STDOUT, json_encode($keypair, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)."\n");
+        fwrite(STDERR, "Store secret_key_b64 only as MODULE_SIGNING_SECRET_KEY_B64 in a protected GitHub environment; add public_key_b64 under key_id to website and InvoiceShelf public-key configuration. Do not commit either output.\n");
+        exit(0);
+    }
+
+    if ($command === 'validate-package') {
+        ManifestValidator::package($target);
+        fwrite(STDOUT, "Valid {$command}: {$target}\n");
+        exit(0);
+    }
+
+    $contents = $target === '-' ? stream_get_contents(STDIN) : file_get_contents($target);
+    if ($contents === false) {
+        throw new RuntimeException("Cannot read {$target}.");
+    }
+    $manifest = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+    if (! is_array($manifest) || array_is_list($manifest)) {
+        throw new RuntimeException('Manifest root must be a JSON object.');
+    }
+
+    if ($command === 'validate-module') {
+        ManifestValidator::module($manifest);
+    } elseif ($command === 'validate-release') {
+        ManifestValidator::release($manifest);
+    } else {
+        fwrite(STDOUT, ManifestValidator::canonicalRelease($manifest));
+        exit(0);
+    }
+
+    fwrite(STDOUT, "Valid {$command} manifest: {$target}\n");
+} catch (Throwable $exception) {
+    fwrite(STDERR, "Invalid manifest: {$exception->getMessage()}\n");
+    exit(1);
+}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.16",
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^11.0",
         "phpunit/phpunit": "^12.0"
     },
     "autoload": {
@@ -27,6 +27,9 @@
             "InvoiceShelf\\Modules\\Tests\\": "tests/"
         }
     },
+    "bin": [
+        "bin/invoiceshelf-module"
+    ],
     "extra": {
         "laravel": {
             "providers": [
@@ -36,7 +39,7 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit",
-        "lint": "vendor/bin/pint"
+        "lint": "vendor/bin/pint --test"
     },
     "config": {
         "allow-plugins": {

--- a/src/InvoiceShelfModulesServiceProvider.php
+++ b/src/InvoiceShelfModulesServiceProvider.php
@@ -55,5 +55,11 @@ class InvoiceShelfModulesServiceProvider extends ServiceProvider
         if (is_dir($stubsPath)) {
             Stub::setBasePath($stubsPath);
         }
+
+        $composerReplacements = $this->app['config']->get('modules.stubs.replacements.composer', []);
+        if (is_array($composerReplacements) && ! in_array('KEBAB_NAME', $composerReplacements, true)) {
+            $composerReplacements[] = 'KEBAB_NAME';
+            $this->app['config']->set('modules.stubs.replacements.composer', $composerReplacements);
+        }
     }
 }

--- a/src/Manifest/CanonicalJson.php
+++ b/src/Manifest/CanonicalJson.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+use JsonException;
+
+/**
+ * Canonical JSON used as the byte representation for marketplace signatures.
+ *
+ * Object keys are sorted lexicographically at every depth. JSON lists retain
+ * their declared order; signatures must therefore be made over this output,
+ * never over a prettified manifest file.
+ */
+final class CanonicalJson
+{
+    /**
+     * @param  array<string, mixed>|list<mixed>  $value
+     *
+     * @throws JsonException
+     */
+    public static function encode(array $value): string
+    {
+        return json_encode(
+            self::sort($value),
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>|list<mixed>  $value
+     * @return array<string, mixed>|list<mixed>
+     */
+    private static function sort(array $value): array
+    {
+        foreach ($value as $key => $item) {
+            if (is_array($item)) {
+                $value[$key] = self::sort($item);
+            }
+        }
+
+        if (! array_is_list($value)) {
+            ksort($value, SORT_STRING);
+        }
+
+        return $value;
+    }
+}

--- a/src/Manifest/Compatibility.php
+++ b/src/Manifest/Compatibility.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+use InvalidArgumentException;
+
+/**
+ * Compatibility gates evaluated by the host before a module is installed.
+ */
+final readonly class Compatibility
+{
+    /**
+     * @param  list<string>  $extensions
+     */
+    public function __construct(
+        public string $invoiceshelf,
+        public string $moduleApi,
+        public string $php,
+        public array $extensions,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    public static function fromArray(array $value): self
+    {
+        self::rejectUnknownKeys($value, ['invoiceshelf', 'module_api', 'php', 'extensions'], 'compatibility');
+
+        foreach (['invoiceshelf', 'module_api', 'php'] as $field) {
+            if (! isset($value[$field]) || ! is_string($value[$field]) || ! Semver::isConstraint($value[$field])) {
+                throw new InvalidArgumentException("Compatibility field '{$field}' must be a supported SemVer constraint.");
+            }
+        }
+
+        if (! isset($value['extensions']) || ! is_array($value['extensions']) || ! array_is_list($value['extensions'])) {
+            throw new InvalidArgumentException("Compatibility field 'extensions' must be a list of PHP extensions.");
+        }
+
+        $extensions = [];
+        foreach ($value['extensions'] as $extension) {
+            if (! is_string($extension) || ! preg_match('/^ext-[a-z0-9][a-z0-9_-]*$/', $extension)) {
+                throw new InvalidArgumentException("Unsupported PHP extension '{$extension}'. Extensions must use the ext-name form.");
+            }
+
+            if (in_array($extension, $extensions, true)) {
+                throw new InvalidArgumentException("Compatibility extension '{$extension}' is duplicated.");
+            }
+
+            $extensions[] = $extension;
+        }
+
+        return new self($value['invoiceshelf'], $value['module_api'], $value['php'], $extensions);
+    }
+
+    /** @return array{invoiceshelf: string, module_api: string, php: string, extensions: list<string>} */
+    public function toArray(): array
+    {
+        return [
+            'invoiceshelf' => $this->invoiceshelf,
+            'module_api' => $this->moduleApi,
+            'php' => $this->php,
+            'extensions' => $this->extensions,
+        ];
+    }
+
+    /** @param array<string, mixed> $value @param list<string> $allowed */
+    private static function rejectUnknownKeys(array $value, array $allowed, string $context): void
+    {
+        $unknown = array_diff(array_keys($value), $allowed);
+        if ($unknown !== []) {
+            throw new InvalidArgumentException("{$context} contains unsupported field '".reset($unknown)."'.");
+        }
+    }
+}

--- a/src/Manifest/Ed25519SignatureVerifier.php
+++ b/src/Manifest/Ed25519SignatureVerifier.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+/** Standard-base64 Ed25519 detached signature verifier; it never owns a private key. */
+final class Ed25519SignatureVerifier implements SignatureVerifier
+{
+    public function verify(string $canonicalJson, string $signature, string $publicKey): bool
+    {
+        if (! function_exists('sodium_crypto_sign_verify_detached')) {
+            return false;
+        }
+
+        $signatureBytes = base64_decode($signature, true);
+        $publicKeyBytes = base64_decode($publicKey, true);
+
+        if ($signatureBytes === false || $publicKeyBytes === false
+            || strlen($signatureBytes) !== SODIUM_CRYPTO_SIGN_BYTES
+            || strlen($publicKeyBytes) !== SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES) {
+            return false;
+        }
+
+        return sodium_crypto_sign_verify_detached($signatureBytes, $canonicalJson, $publicKeyBytes);
+    }
+}

--- a/src/Manifest/ManifestValidator.php
+++ b/src/Manifest/ManifestValidator.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+/** Small facade for CI and host integrations that do not need to know the value object names. */
+final class ManifestValidator
+{
+    /** @param array<string, mixed> $manifest */
+    public static function module(array $manifest): ModuleManifest
+    {
+        return ModuleManifest::fromArray($manifest);
+    }
+
+    /** @param array<string, mixed> $manifest */
+    public static function release(array $manifest): ReleaseManifest
+    {
+        return ReleaseManifest::fromArray($manifest);
+    }
+
+    /** @param array<string, mixed> $manifest */
+    public static function canonicalRelease(array $manifest): string
+    {
+        return self::release($manifest)->canonicalJson();
+    }
+
+    public static function package(string $directory): ModuleManifest
+    {
+        return PackageValidator::validate($directory);
+    }
+}

--- a/src/Manifest/ModuleManifest.php
+++ b/src/Manifest/ModuleManifest.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+use InvalidArgumentException;
+
+/**
+ * Version 1 extension of nwidart's module.json loader descriptor.
+ */
+final readonly class ModuleManifest
+{
+    public const SCHEMA_VERSION = 1;
+
+    /**
+     * @param  list<class-string>  $providers
+     * @param  array<string, string>  $moduleDependencies
+     * @param  list<string>  $assets
+     */
+    public function __construct(
+        public string $slug,
+        public string $name,
+        public string $alias,
+        public string $description,
+        public array $keywords,
+        public int $priority,
+        public string $version,
+        public string $license,
+        public array $providers,
+        public array $aliases,
+        public array $files,
+        public array $requires,
+        public Compatibility $compatibility,
+        public array $moduleDependencies,
+        public string $migrationPolicy,
+        public string $dependencyPolicy,
+        public array $assets,
+    ) {}
+
+    /** @param array<string, mixed> $value */
+    public static function fromArray(array $value): self
+    {
+        self::rejectUnknownKeys($value, [
+            'name', 'alias', 'description', 'keywords', 'priority', 'providers', 'aliases', 'files', 'requires',
+            'schema_version', 'slug', 'version', 'license', 'compatibility', 'module_dependencies',
+            'migration_policy', 'dependency_policy', 'assets',
+        ]);
+
+        if (($value['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
+            throw new InvalidArgumentException('Only module manifest schema_version=1 is supported.');
+        }
+
+        $slug = self::string($value, 'slug');
+        if (! preg_match('/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug)) {
+            throw new InvalidArgumentException("Module slug '{$slug}' must be lowercase kebab-case.");
+        }
+
+        $moduleName = self::string($value, 'name');
+        if (! preg_match('/^[A-Z][A-Za-z0-9]*$/', $moduleName)) {
+            throw new InvalidArgumentException("Module name '{$moduleName}' must be PascalCase ASCII.");
+        }
+
+        $alias = self::string($value, 'alias');
+        if (! preg_match('/^[a-z][a-z0-9_]*$/', $alias)) {
+            throw new InvalidArgumentException("Module alias '{$alias}' must be lowercase ASCII with optional underscores.");
+        }
+        $description = $value['description'] ?? null;
+        if (! is_string($description)) {
+            throw new InvalidArgumentException("Module manifest field 'description' must be a string.");
+        }
+        $keywords = self::stringList($value['keywords'] ?? null, 'keywords');
+        $priority = $value['priority'] ?? null;
+        if (! is_int($priority) || $priority < 0) {
+            throw new InvalidArgumentException("Module manifest field 'priority' must be a non-negative integer.");
+        }
+
+        $version = self::string($value, 'version');
+        if (! Semver::isVersion($version)) {
+            throw new InvalidArgumentException("Module version '{$version}' must be a SemVer version.");
+        }
+
+        $license = self::string($value, 'license');
+        if ($license !== 'AGPL-3.0-only') {
+            throw new InvalidArgumentException("Module license '{$license}' must be AGPL-3.0-only.");
+        }
+
+        $providers = self::providers($value['providers'] ?? null, $moduleName);
+        $compatibility = is_array($value['compatibility'] ?? null)
+            ? Compatibility::fromArray($value['compatibility'])
+            : throw new InvalidArgumentException("Module manifest must declare a 'compatibility' object.");
+
+        $dependencies = self::dependencies($value['module_dependencies'] ?? null, $slug);
+
+        if (($value['migration_policy'] ?? null) !== 'forward-only') {
+            throw new InvalidArgumentException("Only migration_policy 'forward-only' is supported.");
+        }
+
+        if (($value['dependency_policy'] ?? null) !== 'host-provided-only') {
+            throw new InvalidArgumentException("Only dependency_policy 'host-provided-only' is supported; runtime Composer and Node dependencies are forbidden.");
+        }
+
+        return new self(
+            $slug,
+            $moduleName,
+            $alias,
+            $description,
+            $keywords,
+            $priority,
+            $version,
+            $license,
+            $providers,
+            self::map($value['aliases'] ?? null, 'aliases'),
+            self::localFiles($value['files'] ?? null),
+            self::map($value['requires'] ?? null, 'requires'),
+            $compatibility,
+            $dependencies,
+            'forward-only',
+            'host-provided-only',
+            self::assets($value['assets'] ?? null),
+        );
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'slug' => $this->slug,
+            'name' => $this->name,
+            'alias' => $this->alias,
+            'description' => $this->description,
+            'keywords' => $this->keywords,
+            'priority' => $this->priority,
+            'version' => $this->version,
+            'license' => $this->license,
+            'providers' => $this->providers,
+            'aliases' => $this->aliases,
+            'files' => $this->files,
+            'requires' => $this->requires,
+            'compatibility' => $this->compatibility->toArray(),
+            'module_dependencies' => $this->moduleDependencies,
+            'migration_policy' => $this->migrationPolicy,
+            'dependency_policy' => $this->dependencyPolicy,
+            'assets' => $this->assets,
+        ];
+    }
+
+    /** @param array<string, mixed> $value */
+    private static function string(array $value, string $field): string
+    {
+        if (! isset($value[$field]) || ! is_string($value[$field]) || $value[$field] === '') {
+            throw new InvalidArgumentException("Module manifest field '{$field}' must be a non-empty string.");
+        }
+
+        return $value[$field];
+    }
+
+    /** @return list<class-string> */
+    private static function providers(mixed $value, string $moduleName): array
+    {
+        if (! is_array($value) || ! array_is_list($value) || $value === []) {
+            throw new InvalidArgumentException("Module manifest field 'providers' must be a non-empty list.");
+        }
+
+        $providers = [];
+        $prefix = 'Modules\\'.$moduleName.'\\';
+        foreach ($value as $provider) {
+            if (! is_string($provider) || ! str_starts_with($provider, $prefix)
+                || ! preg_match('/^Modules\\\\[A-Za-z][A-Za-z0-9]*(?:\\\\[A-Za-z][A-Za-z0-9]*)*$/', $provider)) {
+                throw new InvalidArgumentException("Provider '{$provider}' must be a class in the Modules\\{$moduleName} namespace.");
+            }
+            if (in_array($provider, $providers, true)) {
+                throw new InvalidArgumentException("Provider '{$provider}' is duplicated.");
+            }
+            $providers[] = $provider;
+        }
+
+        return $providers;
+    }
+
+    /** @return list<string> */
+    private static function stringList(mixed $value, string $field): array
+    {
+        if (! is_array($value) || ! array_is_list($value)) {
+            throw new InvalidArgumentException("Module manifest field '{$field}' must be a list of strings.");
+        }
+        foreach ($value as $item) {
+            if (! is_string($item)) {
+                throw new InvalidArgumentException("Module manifest field '{$field}' must be a list of strings.");
+            }
+        }
+
+        return $value;
+    }
+
+    /** @return array<string, mixed> */
+    private static function map(mixed $value, string $field): array
+    {
+        if (! is_array($value) || (array_is_list($value) && $value !== [])) {
+            throw new InvalidArgumentException("Module manifest field '{$field}' must be an object.");
+        }
+
+        return $value;
+    }
+
+    /** @return list<string> */
+    private static function localFiles(mixed $value): array
+    {
+        $files = self::stringList($value, 'files');
+        foreach ($files as $file) {
+            if (! preg_match('#^[A-Za-z0-9][A-Za-z0-9._/-]*$#', $file) || str_contains($file, '..') || str_contains($file, '//')) {
+                throw new InvalidArgumentException("Module loader file '{$file}' must be a local relative path.");
+            }
+        }
+
+        return $files;
+    }
+
+    /** @return array<string, string> */
+    private static function dependencies(mixed $value, string $ownSlug): array
+    {
+        if (! is_array($value) || (array_is_list($value) && $value !== [])) {
+            throw new InvalidArgumentException("Module manifest field 'module_dependencies' must be an object.");
+        }
+
+        foreach ($value as $slug => $constraint) {
+            if (! is_string($slug) || ! preg_match('/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug) || $slug === $ownSlug) {
+                throw new InvalidArgumentException("Module dependency '{$slug}' must be another lowercase kebab-case module slug.");
+            }
+            if (! Semver::isConstraint($constraint)) {
+                throw new InvalidArgumentException("Module dependency '{$slug}' must use a supported SemVer constraint.");
+            }
+        }
+
+        ksort($value, SORT_STRING);
+
+        /** @var array<string, string> $value */
+        return $value;
+    }
+
+    /** @return list<string> */
+    private static function assets(mixed $value): array
+    {
+        if (! is_array($value) || ! array_is_list($value)) {
+            throw new InvalidArgumentException("Module manifest field 'assets' must be a list of local compiled assets.");
+        }
+
+        $assets = [];
+        foreach ($value as $asset) {
+            if (! is_string($asset) || ! preg_match('#^dist/[A-Za-z0-9][A-Za-z0-9._/-]*\.(?:js|css)$#', $asset)
+                || str_contains($asset, '..') || str_contains($asset, '//')) {
+                throw new InvalidArgumentException("Asset '{$asset}' must be a local dist/*.js or dist/*.css path; remote and source assets are forbidden.");
+            }
+            if (in_array($asset, $assets, true)) {
+                throw new InvalidArgumentException("Asset '{$asset}' is duplicated.");
+            }
+            $assets[] = $asset;
+        }
+
+        return $assets;
+    }
+
+    /** @param array<string, mixed> $value @param list<string> $allowed */
+    private static function rejectUnknownKeys(array $value, array $allowed): void
+    {
+        $unknown = array_diff(array_keys($value), $allowed);
+        if ($unknown !== []) {
+            throw new InvalidArgumentException("Module manifest contains unsupported field '".reset($unknown)."'.");
+        }
+    }
+}

--- a/src/Manifest/PackageValidator.php
+++ b/src/Manifest/PackageValidator.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+use InvalidArgumentException;
+use JsonException;
+
+/** Validates the releaseable module directory, including its local build output. */
+final class PackageValidator
+{
+    /**
+     * @throws JsonException
+     */
+    public static function validate(string $directory): ModuleManifest
+    {
+        $root = realpath($directory);
+        if ($root === false || ! is_dir($root)) {
+            throw new InvalidArgumentException("Module package directory '{$directory}' cannot be read.");
+        }
+
+        $manifest = self::jsonFile($root.'/module.json', 'module.json');
+        $module = ModuleManifest::fromArray($manifest);
+
+        foreach ($module->assets as $asset) {
+            $path = realpath($root.DIRECTORY_SEPARATOR.$asset);
+            if ($path === false || ! str_starts_with($path, $root.DIRECTORY_SEPARATOR) || ! is_file($path)) {
+                throw new InvalidArgumentException("Declared compiled asset '{$asset}' is missing from the module package.");
+            }
+        }
+
+        self::validateComposer($root.'/composer.json', $module->slug);
+
+        return $module;
+    }
+
+    /** @return array<string, mixed> */
+    private static function jsonFile(string $path, string $name): array
+    {
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            throw new InvalidArgumentException("Module package must contain {$name}.");
+        }
+
+        $decoded = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            throw new InvalidArgumentException("{$name} must contain a JSON object.");
+        }
+
+        return $decoded;
+    }
+
+    private static function validateComposer(string $path, string $slug): void
+    {
+        $composer = self::jsonFile($path, 'composer.json');
+        if (($composer['name'] ?? null) !== "invoiceshelf/module-{$slug}") {
+            throw new InvalidArgumentException("composer.json name must be invoiceshelf/module-{$slug}.");
+        }
+        if (($composer['license'] ?? null) !== 'AGPL-3.0-only') {
+            throw new InvalidArgumentException('composer.json license must be AGPL-3.0-only.');
+        }
+        if (! is_array($composer['require'] ?? null) || array_is_list($composer['require'])) {
+            throw new InvalidArgumentException('composer.json must declare a require object.');
+        }
+
+        foreach ($composer['require'] as $package => $constraint) {
+            if (! is_string($package) || ! is_string($constraint)
+                || (! in_array($package, ['php', 'invoiceshelf/modules'], true) && ! str_starts_with($package, 'ext-'))) {
+                throw new InvalidArgumentException("composer.json dependency '{$package}' is not host-provided.");
+            }
+            if (($package === 'php' || $package === 'invoiceshelf/modules') && ! Semver::isConstraint($constraint)
+                || str_starts_with($package, 'ext-') && $constraint !== '*' && ! Semver::isConstraint($constraint)) {
+                throw new InvalidArgumentException("composer.json dependency '{$package}' must use a supported SemVer constraint.");
+            }
+        }
+    }
+}

--- a/src/Manifest/ReleaseEnvelope.php
+++ b/src/Manifest/ReleaseEnvelope.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+use InvalidArgumentException;
+
+/**
+ * Transport envelope returned by the marketplace. The signature covers only
+ * manifest; this class protects the duplicated artifact/key data from a
+ * transport-level substitution and keeps mutable yank state outside signing.
+ */
+final readonly class ReleaseEnvelope
+{
+    public function __construct(
+        public ReleaseManifest $manifest,
+        public string $signature,
+        public string $keyId,
+        public string $downloadUrl,
+        public string $expiresAt,
+        public string $releaseState,
+        public ?string $yankedReason,
+    ) {}
+
+    /** @param array<string, mixed> $value */
+    public static function fromArray(array $value): self
+    {
+        self::rejectUnknownKeys($value, ['success', 'manifest', 'signature', 'key_id', 'artifact', 'release_state', 'yanked_reason']);
+
+        if (($value['success'] ?? null) !== true) {
+            throw new InvalidArgumentException('Release envelope must have success=true.');
+        }
+        if (! is_array($value['manifest'] ?? null)) {
+            throw new InvalidArgumentException("Release envelope must contain a 'manifest' object.");
+        }
+        $manifest = ReleaseManifest::fromArray($value['manifest']);
+
+        $signature = $value['signature'] ?? null;
+        if (! is_string($signature) || base64_decode($signature, true) === false) {
+            throw new InvalidArgumentException('Release envelope signature must be standard base64.');
+        }
+        $keyId = $value['key_id'] ?? null;
+        if (! is_string($keyId) || $keyId !== $manifest->keyId) {
+            throw new InvalidArgumentException('Release envelope key_id must match the signed manifest key_id.');
+        }
+
+        $artifact = $value['artifact'] ?? null;
+        if (! is_array($artifact) || array_diff(array_keys($artifact), ['sha256', 'bytes', 'download_url', 'expires_at']) !== []) {
+            throw new InvalidArgumentException('Release envelope artifact must contain sha256, bytes, download_url, and expires_at only.');
+        }
+        if (($artifact['sha256'] ?? null) !== $manifest->artifactSha256 || ($artifact['bytes'] ?? null) !== $manifest->artifactBytes) {
+            throw new InvalidArgumentException('Release envelope artifact sha256 and bytes must match the signed manifest.');
+        }
+        if (! isset($artifact['download_url']) || ! is_string($artifact['download_url']) || filter_var($artifact['download_url'], FILTER_VALIDATE_URL) === false) {
+            throw new InvalidArgumentException('Release envelope artifact download_url must be an absolute URL.');
+        }
+        $expiresAt = $artifact['expires_at'] ?? null;
+        if (! is_string($expiresAt) || ! self::isRfc3339($expiresAt)) {
+            throw new InvalidArgumentException('Release envelope artifact expires_at must be an RFC 3339 timestamp.');
+        }
+
+        $state = $value['release_state'] ?? 'published';
+        if (! is_string($state) || ! in_array($state, ['published', 'yanked'], true)) {
+            throw new InvalidArgumentException("Release envelope release_state must be 'published' or 'yanked'.");
+        }
+        $reason = $value['yanked_reason'] ?? null;
+        if ($state === 'yanked' && (! is_string($reason) || trim($reason) === '')) {
+            throw new InvalidArgumentException('A yanked release envelope must include a non-empty yanked_reason.');
+        }
+        if ($state === 'published' && $reason !== null) {
+            throw new InvalidArgumentException('A published release envelope cannot include yanked_reason.');
+        }
+
+        return new self($manifest, $signature, $keyId, $artifact['download_url'], $expiresAt, $state, $reason);
+    }
+
+    /** @param array<string, string> $publicKeys Keyed by stable key_id. */
+    public function hasValidSignature(array $publicKeys, ?SignatureVerifier $verifier = null): bool
+    {
+        $publicKey = $publicKeys[$this->keyId] ?? null;
+        if (! is_string($publicKey)) {
+            return false;
+        }
+
+        return ($verifier ?? new Ed25519SignatureVerifier)->verify(
+            $this->manifest->canonicalJson(),
+            $this->signature,
+            $publicKey,
+        );
+    }
+
+    private static function isRfc3339(string $value): bool
+    {
+        return preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/', $value) === 1;
+    }
+
+    /** @param array<string, mixed> $value @param list<string> $allowed */
+    private static function rejectUnknownKeys(array $value, array $allowed): void
+    {
+        $unknown = array_diff(array_keys($value), $allowed);
+        if ($unknown !== []) {
+            throw new InvalidArgumentException("Release envelope contains unsupported field '".reset($unknown)."'.");
+        }
+    }
+}

--- a/src/Manifest/ReleaseManifest.php
+++ b/src/Manifest/ReleaseManifest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+
+/**
+ * Immutable, signed marketplace release record. A later yank is catalog state,
+ * not part of this object: the website must never need a signing key to yank a
+ * compromised release.
+ */
+final readonly class ReleaseManifest
+{
+    public const SCHEMA_VERSION = 1;
+
+    public function __construct(
+        public string $slug,
+        public string $moduleName,
+        public string $version,
+        public string $channel,
+        public string $publication,
+        public Compatibility $compatibility,
+        public string $artifactSha256,
+        public int $artifactBytes,
+        public string $keyId,
+        public string $sourceCommit,
+        public string $releasedAt,
+    ) {}
+
+    /** @param array<string, mixed> $value */
+    public static function fromArray(array $value): self
+    {
+        self::rejectUnknownKeys($value, [
+            'schema_version', 'slug', 'module_name', 'version', 'channel', 'publication', 'compatibility',
+            'artifact', 'key_id', 'source_commit', 'released_at',
+        ]);
+
+        if (($value['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
+            throw new InvalidArgumentException('Only release manifest schema_version=1 is supported.');
+        }
+
+        $slug = self::slug($value['slug'] ?? null);
+        $moduleName = self::moduleName($value['module_name'] ?? null);
+        $version = $value['version'] ?? null;
+        if (! Semver::isVersion($version)) {
+            throw new InvalidArgumentException('Release manifest version must be a SemVer version.');
+        }
+
+        $channel = $value['channel'] ?? null;
+        if (! is_string($channel) || ! in_array($channel, ['stable', 'insider'], true)) {
+            throw new InvalidArgumentException("Release channel must be either 'stable' or 'insider'.");
+        }
+        if ($channel === 'stable' && str_contains($version, '-')) {
+            throw new InvalidArgumentException('Stable releases cannot use a prerelease SemVer version.');
+        }
+        if ($channel === 'insider' && ! str_contains($version, '-')) {
+            throw new InvalidArgumentException('Insider releases must use a prerelease SemVer version.');
+        }
+
+        if (($value['publication'] ?? null) !== 'published') {
+            throw new InvalidArgumentException("Signed release publication must be the immutable marker 'published'. Yank state belongs to the catalog envelope.");
+        }
+
+        $compatibility = is_array($value['compatibility'] ?? null)
+            ? Compatibility::fromArray($value['compatibility'])
+            : throw new InvalidArgumentException("Release manifest must declare a 'compatibility' object.");
+        [$sha256, $bytes] = self::artifact($value['artifact'] ?? null);
+
+        $keyId = $value['key_id'] ?? null;
+        if (! is_string($keyId) || ! preg_match('/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/', $keyId)) {
+            throw new InvalidArgumentException('Release key_id must be a stable, non-empty key identifier.');
+        }
+
+        $commit = $value['source_commit'] ?? null;
+        if (! is_string($commit) || ! preg_match('/^[0-9a-f]{40}$/', $commit)) {
+            throw new InvalidArgumentException('Release source_commit must be a lowercase 40-character Git SHA-1.');
+        }
+
+        $releasedAt = self::date($value['released_at'] ?? null);
+
+        return new self($slug, $moduleName, $version, $channel, 'published', $compatibility, $sha256, $bytes, $keyId, $commit, $releasedAt);
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'slug' => $this->slug,
+            'module_name' => $this->moduleName,
+            'version' => $this->version,
+            'channel' => $this->channel,
+            'publication' => $this->publication,
+            'compatibility' => $this->compatibility->toArray(),
+            'artifact' => ['sha256' => $this->artifactSha256, 'bytes' => $this->artifactBytes],
+            'key_id' => $this->keyId,
+            'source_commit' => $this->sourceCommit,
+            'released_at' => $this->releasedAt,
+        ];
+    }
+
+    public function canonicalJson(): string
+    {
+        return CanonicalJson::encode($this->toArray());
+    }
+
+    /** @return array{string, int} */
+    private static function artifact(mixed $value): array
+    {
+        if (! is_array($value) || array_diff(array_keys($value), ['sha256', 'bytes']) !== []) {
+            throw new InvalidArgumentException("Release artifact must contain only 'sha256' and 'bytes'.");
+        }
+        if (! isset($value['sha256']) || ! is_string($value['sha256']) || ! preg_match('/^[0-9a-f]{64}$/', $value['sha256'])) {
+            throw new InvalidArgumentException('Release artifact sha256 must be lowercase hexadecimal SHA-256.');
+        }
+        if (! isset($value['bytes']) || ! is_int($value['bytes']) || $value['bytes'] < 1) {
+            throw new InvalidArgumentException('Release artifact bytes must be a positive integer.');
+        }
+
+        return [$value['sha256'], $value['bytes']];
+    }
+
+    private static function slug(mixed $value): string
+    {
+        if (! is_string($value) || ! preg_match('/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $value)) {
+            throw new InvalidArgumentException('Release slug must be lowercase kebab-case.');
+        }
+
+        return $value;
+    }
+
+    private static function moduleName(mixed $value): string
+    {
+        if (! is_string($value) || ! preg_match('/^[A-Z][A-Za-z0-9]*$/', $value)) {
+            throw new InvalidArgumentException('Release module_name must be PascalCase ASCII.');
+        }
+
+        return $value;
+    }
+
+    private static function date(mixed $value): string
+    {
+        if (! is_string($value) || preg_match('/^(?<date_time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(?<fraction>\d+))?(?<timezone>Z|[+-]\d{2}:\d{2})$/', $value, $matches) !== 1) {
+            throw new InvalidArgumentException('Release released_at must be an RFC 3339 timestamp with timezone.');
+        }
+
+        $timezone = $matches['timezone'] === 'Z' ? '+00:00' : $matches['timezone'];
+        if ($timezone !== '+00:00') {
+            $timezoneHour = (int) substr($timezone, 1, 2);
+            $timezoneMinute = (int) substr($timezone, 4, 2);
+            if ($timezoneHour > 23 || $timezoneMinute > 59) {
+                throw new InvalidArgumentException('Release released_at must be a valid RFC 3339 timestamp.');
+            }
+        }
+
+        // DateTimeImmutable accepts a maximum of microsecond precision. Preserve
+        // the original fractional text for the signed manifest, but use its first
+        // six digits to validate the calendar date, clock time, and offset.
+        $fraction = substr(str_pad($matches['fraction'] ?? '', 6, '0'), 0, 6);
+        $parsed = DateTimeImmutable::createFromFormat(
+            '!Y-m-d\\TH:i:s.uP',
+            $matches['date_time'].'.'.$fraction.$timezone,
+        );
+        $errors = DateTimeImmutable::getLastErrors();
+
+        if ($parsed === false || ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0))
+            || $parsed->format('Y-m-d\\TH:i:s.uP') !== $matches['date_time'].'.'.$fraction.$timezone) {
+            throw new InvalidArgumentException('Release released_at must be a valid RFC 3339 timestamp.');
+        }
+
+        return $value;
+    }
+
+    /** @param array<string, mixed> $value @param list<string> $allowed */
+    private static function rejectUnknownKeys(array $value, array $allowed): void
+    {
+        $unknown = array_diff(array_keys($value), $allowed);
+        if ($unknown !== []) {
+            throw new InvalidArgumentException("Release manifest contains unsupported field '".reset($unknown)."'.");
+        }
+    }
+}

--- a/src/Manifest/Semver.php
+++ b/src/Manifest/Semver.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+/** Limited, intentionally portable SemVer and Composer-style range grammar. */
+final class Semver
+{
+    private const VERSION = '(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?';
+
+    private const CONSTRAINT_VERSION = '(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?';
+
+    public static function isVersion(mixed $value): bool
+    {
+        return is_string($value) && preg_match('/^'.self::VERSION.'$/', $value) === 1;
+    }
+
+    public static function isConstraint(mixed $value): bool
+    {
+        if (! is_string($value) || $value === '' || str_contains($value, '||') || str_contains($value, '*')) {
+            return false;
+        }
+
+        $comparator = '(?:\^|~|>=|<=|>|<|=)?';
+        $part = $comparator.'v?'.self::CONSTRAINT_VERSION;
+
+        return preg_match('/^'.$part.'(?:\s+'.$part.')*$/', $value) === 1;
+    }
+}

--- a/src/Manifest/SignatureVerifier.php
+++ b/src/Manifest/SignatureVerifier.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+interface SignatureVerifier
+{
+    /** Verifies a detached signature over the exact canonical JSON bytes. */
+    public function verify(string $canonicalJson, string $signature, string $publicKey): bool;
+}

--- a/src/Manifest/SigningKeyPairGenerator.php
+++ b/src/Manifest/SigningKeyPairGenerator.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * Generates a keypair for a protected CI environment without persisting it.
+ * The caller is responsible for placing only the returned secret in its
+ * protected GitHub environment and distributing the public key to verifiers.
+ */
+final class SigningKeyPairGenerator
+{
+    /** @return array{key_id: string, public_key_b64: string, secret_key_b64: string} */
+    public static function generate(string $keyId): array
+    {
+        if (! preg_match('/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/', $keyId)) {
+            throw new InvalidArgumentException('Key ID must be a stable, non-empty identifier using letters, numbers, dots, underscores, or hyphens.');
+        }
+        if (! function_exists('sodium_crypto_sign_keypair')) {
+            throw new RuntimeException('The sodium extension is required to generate an Ed25519 keypair.');
+        }
+
+        $keypair = sodium_crypto_sign_keypair();
+
+        return [
+            'key_id' => $keyId,
+            'public_key_b64' => base64_encode(sodium_crypto_sign_publickey($keypair)),
+            'secret_key_b64' => base64_encode(sodium_crypto_sign_secretkey($keypair)),
+        ];
+    }
+}

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace InvoiceShelf\Modules;
 
+use InvalidArgumentException;
 use InvoiceShelf\Modules\Settings\Schema;
 
 /**
@@ -39,14 +40,12 @@ class Registry
     /**
      * JS/CSS assets a module wants to inject into the host app's main layout.
      *
-     * Stored as `[slug => path]`. Path may be a local file path served by the
-     * host app's ScriptController/StyleController, or a fully-qualified URL
-     * (in which case the host renders a direct <script> tag).
+     * Stored as `[slug => canonical local path]`. Assets must be existing
+     * compiled files inside the installed module package; remote URLs and
+     * runtime-loaded source files are never registered.
      *
-     * Note: this is **not** for shipping Vue components — modules don't ship
-     * SFCs. This is for plain JS/CSS injection (analytics tags, third-party
-     * widgets, custom themes), which is a much smaller surface than runtime
-     * Vue compilation.
+     * Note: this is **not** for shipping Vue components — modules ship only
+     * their pre-built local JS/CSS assets.
      *
      * @var array<string, string>
      */
@@ -167,7 +166,7 @@ class Registry
      */
     public static function registerScript(string $name, string $path): void
     {
-        static::$scripts[$name] = $path;
+        static::$scripts[$name] = self::localAsset($path, 'js');
     }
 
     /**
@@ -175,7 +174,7 @@ class Registry
      */
     public static function registerStyle(string $name, string $path): void
     {
-        static::$styles[$name] = $path;
+        static::$styles[$name] = self::localAsset($path, 'css');
     }
 
     /**
@@ -202,6 +201,24 @@ class Registry
     public static function styleFor(string $name): ?string
     {
         return static::$styles[$name] ?? null;
+    }
+
+    /**
+     * Resolve an installed, compiled asset once at registration time.
+     *
+     * @throws InvalidArgumentException
+     */
+    private static function localAsset(string $path, string $extension): string
+    {
+        $resolved = realpath($path);
+        if ($resolved === false || ! is_file($resolved)) {
+            throw new InvalidArgumentException("Module {$extension} asset '{$path}' must be an existing local file.");
+        }
+        if (strtolower(pathinfo($resolved, PATHINFO_EXTENSION)) !== $extension) {
+            throw new InvalidArgumentException("Module asset '{$path}' must be a .{$extension} file.");
+        }
+
+        return $resolved;
     }
 
     /**

--- a/stubs/composer.stub
+++ b/stubs/composer.stub
@@ -1,6 +1,7 @@
 {
-    "name": "$VENDOR$/$LOWER_NAME$",
+    "name": "invoiceshelf/module-$KEBAB_NAME$",
     "description": "",
+    "license": "AGPL-3.0-only",
     "authors": [
         {
             "name": "$AUTHOR_NAME$",
@@ -8,7 +9,14 @@
         }
     ],
     "require": {
-        "invoiceshelf/modules": "^3.0"
+        "php": "^8.3",
+        "ext-json": "*",
+        "invoiceshelf/modules": "^3.1"
+    },
+    "require-dev": {
+        "laravel/pint": "^1.16",
+        "orchestra/testbench": "^11.0",
+        "phpunit/phpunit": "^12.0"
     },
     "extra": {
         "laravel": {
@@ -29,5 +37,9 @@
         "psr-4": {
             "$MODULE_NAMESPACE$\\$STUDLY_NAME$\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit",
+        "lint": "vendor/bin/pint --test"
     }
 }

--- a/stubs/json.stub
+++ b/stubs/json.stub
@@ -1,0 +1,32 @@
+{
+    "name": "$STUDLY_NAME$",
+    "alias": "$LOWER_NAME$",
+    "description": "",
+    "keywords": [],
+    "priority": 0,
+    "providers": [
+        "$MODULE_NAMESPACE$\\$STUDLY_NAME$\\$PROVIDER_NAMESPACE$\\$STUDLY_NAME$ServiceProvider"
+    ],
+    "aliases": {},
+    "files": [],
+    "requires": {},
+    "schema_version": 1,
+    "slug": "$KEBAB_NAME$",
+    "version": "0.1.0",
+    "license": "AGPL-3.0-only",
+    "compatibility": {
+        "invoiceshelf": "^3.0.0",
+        "module_api": "^1.0.0",
+        "php": "^8.3.0",
+        "extensions": [
+            "ext-json"
+        ]
+    },
+    "module_dependencies": {},
+    "migration_policy": "forward-only",
+    "dependency_policy": "host-provided-only",
+    "assets": [
+        "dist/module.js",
+        "dist/module.css"
+    ]
+}

--- a/tests/Fixtures/module.css
+++ b/tests/Fixtures/module.css
@@ -1,0 +1,1 @@
+.module-fixture { display: block; }

--- a/tests/Fixtures/module.js
+++ b/tests/Fixtures/module.js
@@ -1,0 +1,1 @@
+export const moduleFixture = true;

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -1,0 +1,382 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Tests;
+
+use InvalidArgumentException;
+use InvoiceShelf\Modules\Manifest\CanonicalJson;
+use InvoiceShelf\Modules\Manifest\ModuleManifest;
+use InvoiceShelf\Modules\Manifest\PackageValidator;
+use InvoiceShelf\Modules\Manifest\ReleaseEnvelope;
+use InvoiceShelf\Modules\Manifest\ReleaseManifest;
+use InvoiceShelf\Modules\Manifest\SigningKeyPairGenerator;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class ManifestTest extends TestCase
+{
+    public function test_official_module_composer_stub_uses_the_reserved_package_and_laravel_13_test_stack(): void
+    {
+        $contents = file_get_contents(dirname(__DIR__).'/stubs/composer.stub');
+        $this->assertIsString($contents);
+
+        $stub = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('invoiceshelf/module-$KEBAB_NAME$', $stub['name']);
+        $this->assertSame('AGPL-3.0-only', $stub['license']);
+        $this->assertSame('^8.3', $stub['require']['php']);
+        $this->assertSame('*', $stub['require']['ext-json']);
+        $this->assertSame('^3.1', $stub['require']['invoiceshelf/modules']);
+        $this->assertSame('^11.0', $stub['require-dev']['orchestra/testbench']);
+        $this->assertSame('^12.0', $stub['require-dev']['phpunit/phpunit']);
+        $this->assertSame('vendor/bin/pint --test', $stub['scripts']['lint']);
+    }
+
+    public function test_service_provider_enables_the_kebab_name_composer_replacement(): void
+    {
+        $replacements = $this->app['config']->get('modules.stubs.replacements.composer');
+
+        $this->assertIsArray($replacements);
+        $this->assertContains('KEBAB_NAME', $replacements);
+    }
+
+    public function test_valid_module_manifest_is_normalized(): void
+    {
+        $manifest = ModuleManifest::fromArray($this->moduleManifest());
+
+        $this->assertSame('sales-tax-us', $manifest->slug);
+        $this->assertSame('SalesTaxUs', $manifest->name);
+        $this->assertSame(['ext-mbstring', 'ext-json'], $manifest->compatibility->extensions);
+        $this->assertSame(['accounting-core' => '^1.0.0'], $manifest->moduleDependencies);
+        $this->assertSame(['dist/module.js', 'dist/module.css'], $manifest->assets);
+    }
+
+    public function test_compatibility_accepts_the_standard_short_composer_range_form(): void
+    {
+        $manifest = $this->moduleManifest();
+        $manifest['compatibility']['invoiceshelf'] = '^3.0';
+        $manifest['compatibility']['module_api'] = '^1.0';
+        $manifest['compatibility']['php'] = '>=8.3 <9.0';
+
+        $this->assertSame('^3.0', ModuleManifest::fromArray($manifest)->compatibility->invoiceshelf);
+    }
+
+    #[DataProvider('invalidModuleManifests')]
+    public function test_invalid_module_contracts_are_rejected(string $message, array $changes): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        ModuleManifest::fromArray(array_replace_recursive($this->moduleManifest(), $changes));
+    }
+
+    /** @return iterable<string, array{string, array<string, mixed>}> */
+    public static function invalidModuleManifests(): iterable
+    {
+        yield 'unsupported schema' => ['schema_version=1', ['schema_version' => 2]];
+        yield 'bad slug' => ['lowercase kebab-case', ['slug' => 'Sales Tax']];
+        yield 'bad module name' => ['PascalCase', ['name' => 'sales_tax_us']];
+        yield 'bad version' => ['SemVer', ['version' => 'v1.0']];
+        yield 'non-official license' => ['AGPL-3.0-only', ['license' => 'MIT']];
+        yield 'provider outside module namespace' => ['Modules\\SalesTaxUs namespace', ['providers' => ['App\\Provider']]];
+        yield 'bad host range' => ['supported SemVer constraint', ['compatibility' => ['invoiceshelf' => '*']]];
+        yield 'bad extension' => ['ext-name', ['compatibility' => ['extensions' => ['json']]]];
+        yield 'bad module dependency' => ['another lowercase kebab-case', ['module_dependencies' => ['sales-tax-us' => '^1.0.0']]];
+        yield 'bad dependency range' => ['supported SemVer constraint', ['module_dependencies' => ['other-module' => 'dev-main']]];
+        yield 'rollback migration policy' => ['forward-only', ['migration_policy' => 'reversible']];
+        yield 'runtime dependency policy' => ['host-provided-only', ['dependency_policy' => 'composer-install']];
+        yield 'remote asset' => ['local dist', ['assets' => ['https://cdn.example.test/module.js']]];
+        yield 'source asset' => ['local dist', ['assets' => ['resources/module.ts']]];
+        yield 'unknown key' => ['unsupported field', ['composer_dependencies' => []]];
+    }
+
+    public function test_canonical_json_sorts_objects_and_preserves_lists_exactly(): void
+    {
+        $first = ['z' => ['b' => 1, 'a' => 2], 'a' => ['second', ['z' => 1, 'a' => 2]], 'zero' => 1.0];
+        $second = ['zero' => 1.0, 'a' => ['second', ['a' => 2, 'z' => 1]], 'z' => ['a' => 2, 'b' => 1]];
+
+        $expected = '{"a":["second",{"a":2,"z":1}],"z":{"a":2,"b":1},"zero":1.0}';
+        $this->assertSame($expected, CanonicalJson::encode($first));
+        $this->assertSame($expected, CanonicalJson::encode($second));
+    }
+
+    public function test_keypair_generator_returns_standard_base64_ed25519_material_without_writing_files(): void
+    {
+        $keypair = SigningKeyPairGenerator::generate('official-2026-01');
+
+        $this->assertSame('official-2026-01', $keypair['key_id']);
+        $this->assertSame(SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES, strlen(base64_decode($keypair['public_key_b64'], true)));
+        $this->assertSame(SODIUM_CRYPTO_SIGN_SECRETKEYBYTES, strlen(base64_decode($keypair['secret_key_b64'], true)));
+        $this->assertTrue(sodium_crypto_sign_verify_detached(
+            sodium_crypto_sign_detached('canonical bytes', base64_decode($keypair['secret_key_b64'], true)),
+            'canonical bytes',
+            base64_decode($keypair['public_key_b64'], true),
+        ));
+    }
+
+    public function test_package_validator_requires_built_assets_and_host_provided_composer_dependencies(): void
+    {
+        $directory = sys_get_temp_dir().'/invoiceshelf-modules-'.bin2hex(random_bytes(8));
+        mkdir($directory.'/dist', 0700, true);
+
+        try {
+            file_put_contents($directory.'/module.json', json_encode($this->moduleManifest(), JSON_THROW_ON_ERROR));
+            file_put_contents($directory.'/composer.json', json_encode([
+                'name' => 'invoiceshelf/module-sales-tax-us',
+                'license' => 'AGPL-3.0-only',
+                'require' => ['php' => '^8.3', 'invoiceshelf/modules' => '^3.0', 'ext-json' => '*'],
+            ], JSON_THROW_ON_ERROR));
+            file_put_contents($directory.'/dist/module.js', 'built javascript');
+            file_put_contents($directory.'/dist/module.css', 'built css');
+
+            $this->assertSame('sales-tax-us', PackageValidator::validate($directory)->slug);
+
+            file_put_contents($directory.'/composer.json', json_encode([
+                'name' => 'invoiceshelf/module-sales-tax-us',
+                'license' => 'AGPL-3.0-only',
+                'require' => ['php' => 'not-a-constraint'],
+            ], JSON_THROW_ON_ERROR));
+            try {
+                PackageValidator::validate($directory);
+                $this->fail('An unsupported Composer constraint should be rejected.');
+            } catch (InvalidArgumentException $exception) {
+                $this->assertStringContainsString('supported SemVer constraint', $exception->getMessage());
+            }
+
+            file_put_contents($directory.'/composer.json', json_encode([
+                'name' => 'invoiceshelf/module-sales-tax-us',
+                'license' => 'AGPL-3.0-only',
+                'require' => ['php' => '^8.3', 'invoiceshelf/modules' => '^3.0', 'ext-json' => '*'],
+            ], JSON_THROW_ON_ERROR));
+
+            unlink($directory.'/dist/module.css');
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage('missing');
+            PackageValidator::validate($directory);
+        } finally {
+            foreach (['module.json', 'composer.json', 'dist/module.js', 'dist/module.css'] as $file) {
+                if (is_file($directory.'/'.$file)) {
+                    unlink($directory.'/'.$file);
+                }
+            }
+            if (is_dir($directory.'/dist')) {
+                rmdir($directory.'/dist');
+            }
+            if (is_dir($directory)) {
+                rmdir($directory);
+            }
+        }
+    }
+
+    public function test_valid_stable_release_has_deterministic_canonical_form(): void
+    {
+        $release = ReleaseManifest::fromArray($this->releaseManifest());
+
+        $this->assertSame('stable', $release->channel);
+        $this->assertSame('published', $release->publication);
+        $this->assertSame('2026-08-05T11:30:00Z', $release->releasedAt);
+        $this->assertStringContainsString('"artifact":{"bytes":1234,"sha256":"'.str_repeat('a', 64).'"}', $release->canonicalJson());
+        $this->assertSame($release->canonicalJson(), ReleaseManifest::fromArray(array_reverse($this->releaseManifest()))->canonicalJson());
+    }
+
+    public function test_valid_insider_release_requires_a_prerelease_version(): void
+    {
+        $manifest = $this->releaseManifest();
+        $manifest['channel'] = 'insider';
+        $manifest['version'] = '1.3.0-insider.1';
+
+        $release = ReleaseManifest::fromArray($manifest);
+
+        $this->assertSame('insider', $release->channel);
+        $this->assertSame('1.3.0-insider.1', $release->version);
+    }
+
+    #[DataProvider('validReleaseTimestamps')]
+    public function test_release_timestamp_accepts_z_offset_and_fractional_rfc3339_values(string $timestamp): void
+    {
+        $manifest = $this->releaseManifest();
+        $manifest['released_at'] = $timestamp;
+
+        $release = ReleaseManifest::fromArray($manifest);
+
+        $this->assertSame($timestamp, $release->releasedAt);
+        $this->assertStringContainsString('"released_at":"'.$timestamp.'"', $release->canonicalJson());
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function validReleaseTimestamps(): iterable
+    {
+        yield 'UTC Z timezone' => ['2026-08-05T11:30:00Z'];
+        yield 'numeric timezone offset' => ['2026-08-05T13:00:00+01:30'];
+        yield 'fractional seconds' => ['2026-08-05T11:30:00.123456789Z'];
+    }
+
+    #[DataProvider('invalidReleaseTimestamps')]
+    public function test_release_timestamp_rejects_impossible_or_non_timezoned_values(string $timestamp, string $message): void
+    {
+        $manifest = $this->releaseManifest();
+        $manifest['released_at'] = $timestamp;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        ReleaseManifest::fromArray($manifest);
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function invalidReleaseTimestamps(): iterable
+    {
+        yield 'impossible calendar date' => ['2026-02-31T11:30:00Z', 'valid RFC 3339'];
+        yield 'invalid clock time' => ['2026-08-05T24:00:00Z', 'valid RFC 3339'];
+        yield 'normalized timezone offset' => ['2026-08-05T11:30:00+23:60', 'valid RFC 3339'];
+        yield 'no timezone' => ['2026-08-05T11:30:00', 'with timezone'];
+    }
+
+    #[DataProvider('invalidReleaseManifests')]
+    public function test_invalid_release_contracts_are_rejected(string $message, array $changes): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        ReleaseManifest::fromArray(array_replace_recursive($this->releaseManifest(), $changes));
+    }
+
+    /** @return iterable<string, array{string, array<string, mixed>}> */
+    public static function invalidReleaseManifests(): iterable
+    {
+        yield 'bad channel' => ["either 'stable' or 'insider'", ['channel' => 'beta']];
+        yield 'stable prerelease' => ['Stable releases', ['version' => '1.2.3-rc.1']];
+        yield 'insider regular version' => ['Insider releases', ['channel' => 'insider']];
+        yield 'mutable yanked signed state' => ['immutable marker', ['publication' => 'yanked']];
+        yield 'uppercase checksum' => ['lowercase hexadecimal', ['artifact' => ['sha256' => strtoupper(str_repeat('a', 64))]]];
+        yield 'zero bytes' => ['positive integer', ['artifact' => ['bytes' => 0]]];
+        yield 'bad key id' => ['key_id', ['key_id' => 'bad key']];
+        yield 'bad commit' => ['40-character', ['source_commit' => 'abcdef']];
+        yield 'bad time' => ['RFC 3339', ['released_at' => 'yesterday']];
+        yield 'unknown state field' => ['unsupported field', ['state' => 'published']];
+    }
+
+    public function test_envelope_requires_matching_integrity_metadata_and_verifies_ed25519_signature(): void
+    {
+        $release = ReleaseManifest::fromArray($this->releaseManifest());
+        $keypair = sodium_crypto_sign_keypair();
+        $publicKey = base64_encode(sodium_crypto_sign_publickey($keypair));
+        $signature = base64_encode(sodium_crypto_sign_detached($release->canonicalJson(), sodium_crypto_sign_secretkey($keypair)));
+        $envelope = [
+            'success' => true,
+            'manifest' => $this->releaseManifest(),
+            'signature' => $signature,
+            'key_id' => 'official-2026-01',
+            'artifact' => [
+                'sha256' => str_repeat('a', 64),
+                'bytes' => 1234,
+                'download_url' => 'https://modules.invoiceshelf.com/download/sales-tax-us.zip',
+                'expires_at' => '2026-08-05T12:00:00Z',
+            ],
+        ];
+
+        $parsed = ReleaseEnvelope::fromArray($envelope);
+        $this->assertTrue($parsed->hasValidSignature(['official-2026-01' => $publicKey]));
+
+        $envelope['artifact']['bytes'] = 9;
+        $this->expectExceptionMessage('must match');
+        ReleaseEnvelope::fromArray($envelope);
+    }
+
+    public function test_yanked_catalog_state_requires_reason_and_does_not_change_signed_manifest(): void
+    {
+        $envelope = [
+            'success' => true,
+            'manifest' => $this->releaseManifest(),
+            'signature' => base64_encode(str_repeat('x', SODIUM_CRYPTO_SIGN_BYTES)),
+            'key_id' => 'official-2026-01',
+            'artifact' => [
+                'sha256' => str_repeat('a', 64),
+                'bytes' => 1234,
+                'download_url' => 'https://modules.invoiceshelf.com/download/sales-tax-us.zip',
+                'expires_at' => '2026-08-05T12:00:00Z',
+            ],
+            'release_state' => 'yanked',
+            'yanked_reason' => 'Security issue',
+        ];
+
+        $parsed = ReleaseEnvelope::fromArray($envelope);
+        $this->assertSame('yanked', $parsed->releaseState);
+        $this->assertSame('published', $parsed->manifest->publication);
+    }
+
+    public function test_invalid_yank_catalog_state_is_rejected(): void
+    {
+        $envelope = [
+            'success' => true,
+            'manifest' => $this->releaseManifest(),
+            'signature' => base64_encode(str_repeat('x', SODIUM_CRYPTO_SIGN_BYTES)),
+            'key_id' => 'official-2026-01',
+            'artifact' => [
+                'sha256' => str_repeat('a', 64),
+                'bytes' => 1234,
+                'download_url' => 'https://modules.invoiceshelf.com/download/sales-tax-us.zip',
+                'expires_at' => '2026-08-05T12:00:00Z',
+            ],
+            'release_state' => 'yanked',
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('yanked_reason');
+
+        ReleaseEnvelope::fromArray($envelope);
+    }
+
+    /** @return array<string, mixed> */
+    private function moduleManifest(): array
+    {
+        return [
+            'schema_version' => 1,
+            'slug' => 'sales-tax-us',
+            'name' => 'SalesTaxUs',
+            'alias' => 'salestaxus',
+            'description' => '',
+            'keywords' => [],
+            'priority' => 0,
+            'version' => '1.2.3',
+            'license' => 'AGPL-3.0-only',
+            'providers' => ['Modules\\SalesTaxUs\\Providers\\SalesTaxUsServiceProvider'],
+            'aliases' => [],
+            'files' => [],
+            'requires' => [],
+            'compatibility' => [
+                'invoiceshelf' => '^3.0.0',
+                'module_api' => '^1.0.0',
+                'php' => '^8.3.0',
+                'extensions' => ['ext-mbstring', 'ext-json'],
+            ],
+            'module_dependencies' => ['accounting-core' => '^1.0.0'],
+            'migration_policy' => 'forward-only',
+            'dependency_policy' => 'host-provided-only',
+            'assets' => ['dist/module.js', 'dist/module.css'],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function releaseManifest(): array
+    {
+        return [
+            'schema_version' => 1,
+            'slug' => 'sales-tax-us',
+            'module_name' => 'SalesTaxUs',
+            'version' => '1.2.3',
+            'channel' => 'stable',
+            'publication' => 'published',
+            'compatibility' => [
+                'invoiceshelf' => '^3.0.0',
+                'module_api' => '^1.0.0',
+                'php' => '^8.3.0',
+                'extensions' => ['ext-json'],
+            ],
+            'artifact' => ['sha256' => str_repeat('a', 64), 'bytes' => 1234],
+            'key_id' => 'official-2026-01',
+            'source_commit' => str_repeat('b', 40),
+            'released_at' => '2026-08-05T11:30:00Z',
+        ];
+    }
+}

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -7,7 +7,7 @@ namespace InvoiceShelf\Modules\Tests;
 use InvalidArgumentException;
 use InvoiceShelf\Modules\Registry;
 use InvoiceShelf\Modules\Settings\Schema;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RegistryTest extends TestCase
 {
@@ -230,26 +230,49 @@ class RegistryTest extends TestCase
 
     public function test_register_script_and_style_round_trip(): void
     {
-        Registry::registerScript('analytics', '/path/to/analytics.js');
-        Registry::registerStyle('theme', '/path/to/theme.css');
+        $script = realpath(__DIR__.'/Fixtures/module.js');
+        $style = realpath(__DIR__.'/Fixtures/module.css');
+        $this->assertIsString($script);
+        $this->assertIsString($style);
 
-        $this->assertSame(['analytics' => '/path/to/analytics.js'], Registry::allScripts());
-        $this->assertSame(['theme' => '/path/to/theme.css'], Registry::allStyles());
-        $this->assertSame('/path/to/analytics.js', Registry::scriptFor('analytics'));
-        $this->assertSame('/path/to/theme.css', Registry::styleFor('theme'));
+        Registry::registerScript('analytics', $script);
+        Registry::registerStyle('theme', $style);
+
+        $this->assertSame(['analytics' => $script], Registry::allScripts());
+        $this->assertSame(['theme' => $style], Registry::allStyles());
+        $this->assertSame($script, Registry::scriptFor('analytics'));
+        $this->assertSame($style, Registry::styleFor('theme'));
         $this->assertNull(Registry::scriptFor('does-not-exist'));
         $this->assertNull(Registry::styleFor('does-not-exist'));
     }
 
     public function test_flush_also_clears_scripts_and_styles(): void
     {
-        Registry::registerScript('s', '/s.js');
-        Registry::registerStyle('t', '/t.css');
+        Registry::registerScript('s', __DIR__.'/Fixtures/module.js');
+        Registry::registerStyle('t', __DIR__.'/Fixtures/module.css');
 
         Registry::flush();
 
         $this->assertSame([], Registry::allScripts());
         $this->assertSame([], Registry::allStyles());
+    }
+
+    #[DataProvider('invalidRuntimeAssets')]
+    public function test_remote_missing_and_wrong_extension_runtime_assets_are_rejected(string $method, string $path, string $message): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        Registry::{$method}('asset', $path);
+    }
+
+    /** @return iterable<string, array{string, string, string}> */
+    public static function invalidRuntimeAssets(): iterable
+    {
+        yield 'remote script URL' => ['registerScript', 'https://cdn.example.test/module.js', 'existing local file'];
+        yield 'missing style file' => ['registerStyle', __DIR__.'/Fixtures/missing.css', 'existing local file'];
+        yield 'wrong script extension' => ['registerScript', __DIR__.'/Fixtures/module.css', 'must be a .js file'];
+        yield 'wrong style extension' => ['registerStyle', __DIR__.'/Fixtures/module.js', 'must be a .css file'];
     }
 
     public function test_register_driver_round_trip(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Tests;
+
+use InvoiceShelf\Modules\InvoiceShelfModulesServiceProvider;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+abstract class TestCase extends Orchestra
+{
+    /** @return list<class-string> */
+    protected function getPackageProviders($app): array
+    {
+        return [InvoiceShelfModulesServiceProvider::class];
+    }
+}


### PR DESCRIPTION
## Summary

- define the schema-v1 signed release manifest and strict module package contract
- add canonical JSON and Ed25519 signing/verification commands
- harden module registry discovery and package validation
- add a reusable GitHub release workflow for deterministic ZIP artifacts and marketplace ingestion
- upgrade the SDK test harness for Laravel 13

## Verification

- 71 tests, 167 assertions
- PHP lint and Pint pass
- composer validate passes
- reusable workflow YAML parses successfully

## Rollout

After merge, tag this repository as 3.1.0. Official module repositories can then pin the reusable workflow and SDK constraint to that release.
