### PR TITLE
feat: add reversible module uninstall contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ The actual module loading, file generation, migration, and provider registration
 
 An official module lives in its own repository and Composer package — never in this SDK repository or in the InvoiceShelf application repository. First-party packages use the reserved `invoiceshelf/module-<slug>` convention (the generator's Composer stub uses it automatically); this marketplace contract is for official modules, not a runtime package-install mechanism for arbitrary third-party code. `php artisan module:make` creates the extended `module.json` automatically through this SDK's [`stubs/json.stub`](stubs/json.stub).
 
-`module.json` is schema version 1. Its identity (`slug`, loader `name`) is immutable after the first marketplace release. It preserves nwidart loader keys (`name`, `alias`, `description`, `keywords`, `priority`, `providers`, `aliases`, `files`, and `requires`) and adds an exact SemVer `version`, SPDX `license`, compatibility constraints, required `ext-*` PHP extensions, module-to-module SemVer dependencies, and local compiled `dist/*.js`/`dist/*.css` assets. Unknown fields beyond those defined loader and SDK keys are rejected.
+`module.json` is schema version 2. Its identity (`slug`, loader `name`) is immutable after the first marketplace release. It preserves nwidart loader keys (`name`, `alias`, `description`, `keywords`, `priority`, `providers`, `aliases`, `files`, and `requires`) and adds an exact SemVer `version`, SPDX `license`, compatibility constraints, required `ext-*` PHP extensions, module-to-module SemVer dependencies, local compiled `dist/*.js`/`dist/*.css` assets, and a required uninstall cleanup class. Unknown fields beyond those defined loader and SDK keys are rejected. The SDK continues to parse schema-v1 manifests as legacy forward-only packages; new modules must use schema v2.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "slug": "sales-tax-us",
   "name": "SalesTaxUs",
   "alias": "salestaxus",
@@ -36,18 +36,37 @@ An official module lives in its own repository and Composer package — never in
   "requires": {},
   "compatibility": {
     "invoiceshelf": "^3.0.0",
-    "module_api": "^1.0.0",
+    "module_api": "^1.1.0",
     "php": "^8.3.0",
     "extensions": ["ext-json"]
   },
   "module_dependencies": {"accounting-core": "^1.0.0"},
-  "migration_policy": "forward-only",
+  "migration_policy": "reversible",
   "dependency_policy": "host-provided-only",
+  "uninstall": {
+    "data_cleanup": "Modules\\SalesTaxUs\\Providers\\SalesTaxUsServiceProvider"
+  },
   "assets": ["dist/module.js", "dist/module.css"]
 }
 ```
 
-The policies are deliberately closed: migrations are forward-only and installation never runs Composer, npm, pnpm, or another dependency resolver. Runtime dependencies must be provided by InvoiceShelf (`host-provided-only`). Generated packages use Orchestra Testbench 11 (Laravel 13), PHPUnit 12, and Pint only as `require-dev` CI tooling; build tooling is allowed in CI only, and compiled output is shipped inside the ZIP. Remote URLs, source assets, path traversal, arbitrary PHP providers, unsupported constraints, and unknown manifest fields are rejected.
+The policies are deliberately closed: schema-v2 migrations are reversible and installation never runs Composer, npm, pnpm, or another dependency resolver. Every PHP migration under `database/migrations` (or legacy `Database/Migrations`) must contain exactly one concrete class extending Laravel's `Migration`, with public, non-static, zero-argument, non-empty `up(): void` and `down(): void` methods. The package validator parses those files as PHP ASTs: destructive calls (including `drop*`, `rename*`, `update*`, `raw`, `unprepared`, `statement`, `affectingStatement`, `delete`, and `truncate`) are forbidden in `up()` and allowed in `down()`. Runtime dependencies must be provided by InvoiceShelf (`host-provided-only`). Generated packages use Orchestra Testbench 11 (Laravel 13), PHPUnit 12, and Pint only as `require-dev` CI tooling; build tooling is allowed in CI only, and compiled output is shipped inside the ZIP. Remote URLs, source assets, path traversal, arbitrary PHP providers, unsupported constraints, and unknown manifest fields are rejected.
+
+Schema-v2 manifests must declare `uninstall.data_cleanup` as a class in their own `Modules\\<Name>\\...` namespace. That class must implement `InvoiceShelf\\Modules\\Contracts\\DataCleanup`:
+
+```php
+use InvoiceShelf\Modules\Contracts\DataCleanup;
+
+final class SalesTaxUsCleanup implements DataCleanup
+{
+    public function cleanup(): void
+    {
+        // Delete module-owned external resources or data outside down() migrations.
+    }
+}
+```
+
+`cleanup()` must be idempotent because uninstall may be retried; an exception signals failure and must stop the uninstall. Its body may intentionally be empty for a no-op cleanup, but its class must be concrete and its method must be a non-static, non-abstract, zero-argument public `cleanup(): void` implementation. During uninstall, the host calls this developer cleanup first while module tables still exist, then runs every migration's `down()` method, and finally removes host-owned module settings. The scaffold uses its generated service provider as the default cleanup class purely for convenience. Modules may instead point `uninstall.data_cleanup` to a dedicated class in their own namespace.
 
 At runtime, `Registry::registerScript()` and `Registry::registerStyle()` accept only existing local `.js` and `.css` files (for example `module_path($name, 'dist/module.js')`). The registry stores the canonical real path and rejects URLs, missing files, and incorrect extensions; modules cannot inject remote scripts or styles.
 

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "license": "MIT",
     "type": "library",
     "require": {
+        "nikic/php-parser": "^5.0",
         "php": "^8.3",
         "nwidart/laravel-modules": "^13.0"
     },

--- a/src/Contracts/DataCleanup.php
+++ b/src/Contracts/DataCleanup.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Contracts;
+
+/**
+ * Removes module-owned data that cannot be removed by reversible migrations.
+ *
+ * Implementations must be idempotent: the host may retry an uninstall after a
+ * failed attempt. Throw an exception when cleanup cannot be completed.
+ */
+interface DataCleanup
+{
+    public function cleanup(): void;
+}

--- a/src/Manifest/CleanupValidator.php
+++ b/src/Manifest/CleanupValidator.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+use FilesystemIterator;
+use InvalidArgumentException;
+use InvoiceShelf\Modules\Contracts\DataCleanup;
+use PhpParser\Error;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/** Confirms a package declares its schema-v2 cleanup class without loading it. */
+final class CleanupValidator
+{
+    public static function validateDirectory(string $directory, string $dataCleanup): void
+    {
+        $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS));
+        foreach ($files as $file) {
+            if (! $file->isFile() || strtolower($file->getExtension()) !== 'php' || self::isExcluded($file->getPathname(), $directory)) {
+                continue;
+            }
+
+            $class = self::findClass($file->getPathname(), $dataCleanup);
+            if ($class !== null) {
+                self::validateClass($class, $dataCleanup);
+
+                return;
+            }
+        }
+
+        throw new InvalidArgumentException("Module uninstall data_cleanup class '{$dataCleanup}' must exist and implement ".DataCleanup::class.'.');
+    }
+
+    private static function findClass(string $path, string $dataCleanup): ?Class_
+    {
+        $source = file_get_contents($path);
+        if ($source === false) {
+            throw new InvalidArgumentException("Module cleanup source '{$path}' cannot be read.");
+        }
+
+        try {
+            $statements = (new ParserFactory)->createForNewestSupportedVersion()->parse($source) ?? [];
+            $traverser = new NodeTraverser;
+            $traverser->addVisitor(new NameResolver);
+            $statements = $traverser->traverse($statements);
+        } catch (Error $error) {
+            throw new InvalidArgumentException("Module cleanup source '{$path}' is not valid PHP: {$error->getMessage()}", previous: $error);
+        }
+
+        foreach ((new NodeFinder)->findInstanceOf($statements, Class_::class) as $class) {
+            if (self::className($class) === $dataCleanup) {
+                return $class;
+            }
+        }
+
+        return null;
+    }
+
+    private static function className(Class_ $class): ?string
+    {
+        $name = $class->namespacedName;
+
+        return $name instanceof Name ? $name->toString() : null;
+    }
+
+    private static function validateClass(Class_ $class, string $dataCleanup): void
+    {
+        $implementsCleanup = false;
+        foreach ($class->implements as $interface) {
+            if (ltrim($interface->toString(), '\\') === DataCleanup::class) {
+                $implementsCleanup = true;
+                break;
+            }
+        }
+        if (! $implementsCleanup) {
+            throw new InvalidArgumentException("Module uninstall data_cleanup class '{$dataCleanup}' must implement ".DataCleanup::class.'.');
+        }
+
+        foreach ($class->getMethods() as $method) {
+            if (strtolower($method->name->toString()) === 'cleanup') {
+                self::validateCleanupMethod($method, $dataCleanup);
+
+                if ($class->isAbstract()) {
+                    throw new InvalidArgumentException("Module uninstall data_cleanup class '{$dataCleanup}' must not be abstract.");
+                }
+
+                return;
+            }
+        }
+
+        throw new InvalidArgumentException("Module uninstall data_cleanup class '{$dataCleanup}' must declare a concrete public cleanup(): void method.");
+    }
+
+    private static function validateCleanupMethod(ClassMethod $method, string $dataCleanup): void
+    {
+        if (! $method->isPublic() || $method->isStatic() || $method->isAbstract() || $method->params !== [] || $method->returnType?->toString() !== 'void') {
+            throw new InvalidArgumentException("Module uninstall data_cleanup class '{$dataCleanup}' must declare a concrete public zero-argument cleanup(): void method.");
+        }
+    }
+
+    private static function isExcluded(string $path, string $directory): bool
+    {
+        $relative = substr($path, strlen(rtrim($directory, DIRECTORY_SEPARATOR)) + 1);
+
+        return $relative !== false && preg_match('#(?:^|/)(?:vendor|node_modules|\.git)(?:/|$)#', str_replace(DIRECTORY_SEPARATOR, '/', $relative)) === 1;
+    }
+}

--- a/src/Manifest/MigrationValidator.php
+++ b/src/Manifest/MigrationValidator.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+use FilesystemIterator;
+use InvalidArgumentException;
+use PhpParser\Error;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/** Validates the reversible migration contract without executing module code. */
+final class MigrationValidator
+{
+    public static function validateDirectory(string $directory): void
+    {
+        if (! is_dir($directory)) {
+            return;
+        }
+
+        $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS));
+        foreach ($files as $file) {
+            if (! $file->isFile() || strtolower($file->getExtension()) !== 'php') {
+                continue;
+            }
+
+            self::validateFile($file->getPathname());
+        }
+    }
+
+    public static function validateFile(string $path): void
+    {
+        $source = file_get_contents($path);
+        if ($source === false) {
+            throw new InvalidArgumentException("Module migration '{$path}' cannot be read.");
+        }
+
+        try {
+            $statements = (new ParserFactory)->createForNewestSupportedVersion()->parse($source) ?? [];
+            $traverser = new NodeTraverser;
+            $traverser->addVisitor(new NameResolver);
+            $statements = $traverser->traverse($statements);
+        } catch (Error $error) {
+            throw new InvalidArgumentException("Module migration '{$path}' is not valid PHP: {$error->getMessage()}", previous: $error);
+        }
+
+        $classes = (new NodeFinder)->findInstanceOf($statements, Class_::class);
+        if (count($classes) !== 1) {
+            throw new InvalidArgumentException("Module migration '{$path}' must declare exactly one concrete Laravel migration class.");
+        }
+
+        self::validateMigrationClass($classes[0], $path);
+    }
+
+    private static function validateMigrationClass(Class_ $class, string $path): void
+    {
+        if ($class->isAbstract() || ltrim($class->extends?->toString() ?? '', '\\') !== 'Illuminate\\Database\\Migrations\\Migration') {
+            throw new InvalidArgumentException("Module migration '{$path}' must extend Illuminate\\Database\\Migrations\\Migration and be concrete.");
+        }
+
+        $up = self::method($class, 'up');
+        $down = self::method($class, 'down');
+
+        self::validateMethod($up, 'up', $path);
+        self::validateMethod($down, 'down', $path);
+
+        foreach ((new NodeFinder)->find($up->stmts, static fn (Node $node): bool => self::isDestructiveCall($node)) as $call) {
+            $name = self::callName($call);
+            throw new InvalidArgumentException("Module migration '{$path}' may not call destructive method '{$name}' from up(). Destructive calls are allowed only in down().");
+        }
+    }
+
+    private static function method(Class_ $class, string $name): ?ClassMethod
+    {
+        foreach ($class->getMethods() as $method) {
+            if (strtolower($method->name->toString()) === $name) {
+                return $method;
+            }
+        }
+
+        return null;
+    }
+
+    private static function validateMethod(?ClassMethod $method, string $name, string $path): void
+    {
+        if ($method === null || ! $method->isPublic() || $method->isStatic() || $method->params !== []
+            || $method->stmts === null || $method->stmts === [] || $method->returnType?->toString() !== 'void') {
+            throw new InvalidArgumentException("Module migration '{$path}' must declare a public, non-static, zero-argument, non-empty {$name}(): void method.");
+        }
+    }
+
+    private static function isDestructiveCall(Node $node): bool
+    {
+        if (! ($node instanceof MethodCall || $node instanceof StaticCall || $node instanceof FuncCall)) {
+            return false;
+        }
+
+        $name = self::callName($node);
+
+        return str_starts_with($name, 'drop')
+            || str_starts_with($name, 'rename')
+            || str_starts_with($name, 'delete')
+            || str_starts_with($name, 'truncate')
+            || str_starts_with($name, 'update')
+            || in_array($name, ['raw', 'unprepared', 'statement', 'affectingstatement'], true);
+    }
+
+    private static function callName(MethodCall|StaticCall|FuncCall $call): string
+    {
+        if ($call->name instanceof Identifier) {
+            return strtolower($call->name->toString());
+        }
+
+        return $call->name instanceof Name ? strtolower($call->name->getLast()) : '';
+    }
+}

--- a/src/Manifest/ModuleManifest.php
+++ b/src/Manifest/ModuleManifest.php
@@ -7,11 +7,13 @@ namespace InvoiceShelf\Modules\Manifest;
 use InvalidArgumentException;
 
 /**
- * Version 1 extension of nwidart's module.json loader descriptor.
+ * Versioned extension of nwidart's module.json loader descriptor.
  */
 final readonly class ModuleManifest
 {
-    public const SCHEMA_VERSION = 1;
+    public const SCHEMA_VERSION = 2;
+
+    public const LEGACY_SCHEMA_VERSION = 1;
 
     /**
      * @param  list<class-string>  $providers
@@ -36,6 +38,7 @@ final readonly class ModuleManifest
         public string $migrationPolicy,
         public string $dependencyPolicy,
         public array $assets,
+        public ?Uninstall $uninstall = null,
     ) {}
 
     /** @param array<string, mixed> $value */
@@ -44,11 +47,12 @@ final readonly class ModuleManifest
         self::rejectUnknownKeys($value, [
             'name', 'alias', 'description', 'keywords', 'priority', 'providers', 'aliases', 'files', 'requires',
             'schema_version', 'slug', 'version', 'license', 'compatibility', 'module_dependencies',
-            'migration_policy', 'dependency_policy', 'assets',
+            'migration_policy', 'dependency_policy', 'assets', 'uninstall',
         ]);
 
-        if (($value['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
-            throw new InvalidArgumentException('Only module manifest schema_version=1 is supported.');
+        $schemaVersion = $value['schema_version'] ?? null;
+        if (! in_array($schemaVersion, [self::LEGACY_SCHEMA_VERSION, self::SCHEMA_VERSION], true)) {
+            throw new InvalidArgumentException('Only module manifest schema_version=1 or schema_version=2 is supported.');
         }
 
         $slug = self::string($value, 'slug');
@@ -92,8 +96,12 @@ final readonly class ModuleManifest
 
         $dependencies = self::dependencies($value['module_dependencies'] ?? null, $slug);
 
-        if (($value['migration_policy'] ?? null) !== 'forward-only') {
-            throw new InvalidArgumentException("Only migration_policy 'forward-only' is supported.");
+        $migrationPolicy = $value['migration_policy'] ?? null;
+        if ($schemaVersion === self::LEGACY_SCHEMA_VERSION && $migrationPolicy !== 'forward-only') {
+            throw new InvalidArgumentException("Module manifest schema_version=1 requires migration_policy 'forward-only'.");
+        }
+        if ($schemaVersion === self::SCHEMA_VERSION && $migrationPolicy !== 'reversible') {
+            throw new InvalidArgumentException("Module manifest schema_version=2 requires migration_policy 'reversible'.");
         }
 
         if (($value['dependency_policy'] ?? null) !== 'host-provided-only') {
@@ -115,9 +123,10 @@ final readonly class ModuleManifest
             self::map($value['requires'] ?? null, 'requires'),
             $compatibility,
             $dependencies,
-            'forward-only',
+            $migrationPolicy,
             'host-provided-only',
             self::assets($value['assets'] ?? null),
+            self::uninstall($value, $moduleName, $schemaVersion),
         );
     }
 
@@ -125,7 +134,7 @@ final readonly class ModuleManifest
     public function toArray(): array
     {
         return [
-            'schema_version' => self::SCHEMA_VERSION,
+            'schema_version' => $this->uninstall === null ? self::LEGACY_SCHEMA_VERSION : self::SCHEMA_VERSION,
             'slug' => $this->slug,
             'name' => $this->name,
             'alias' => $this->alias,
@@ -143,6 +152,7 @@ final readonly class ModuleManifest
             'migration_policy' => $this->migrationPolicy,
             'dependency_policy' => $this->dependencyPolicy,
             'assets' => $this->assets,
+            ...($this->uninstall === null ? [] : ['uninstall' => $this->uninstall->toArray()]),
         ];
     }
 
@@ -259,6 +269,24 @@ final readonly class ModuleManifest
         }
 
         return $assets;
+    }
+
+    /** @param array<string, mixed> $value */
+    private static function uninstall(array $value, string $moduleName, int $schemaVersion): ?Uninstall
+    {
+        if ($schemaVersion === self::LEGACY_SCHEMA_VERSION) {
+            if (array_key_exists('uninstall', $value)) {
+                throw new InvalidArgumentException("Module manifest schema_version=1 does not support 'uninstall'.");
+            }
+
+            return null;
+        }
+
+        if (! is_array($value['uninstall'] ?? null) || array_is_list($value['uninstall'])) {
+            throw new InvalidArgumentException("Module manifest schema_version=2 must declare an 'uninstall' object.");
+        }
+
+        return Uninstall::fromArray($value['uninstall'], $moduleName);
     }
 
     /** @param array<string, mixed> $value @param list<string> $allowed */

--- a/src/Manifest/PackageValidator.php
+++ b/src/Manifest/PackageValidator.php
@@ -32,6 +32,15 @@ final class PackageValidator
 
         self::validateComposer($root.'/composer.json', $module->slug);
 
+        if ($module->uninstall !== null) {
+            CleanupValidator::validateDirectory($root, $module->uninstall->dataCleanup);
+        }
+
+        if ($module->migrationPolicy === 'reversible') {
+            MigrationValidator::validateDirectory($root.'/database/migrations');
+            MigrationValidator::validateDirectory($root.'/Database/Migrations');
+        }
+
         return $module;
     }
 

--- a/src/Manifest/Uninstall.php
+++ b/src/Manifest/Uninstall.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Manifest;
+
+use InvalidArgumentException;
+use InvoiceShelf\Modules\Contracts\DataCleanup;
+
+/** Schema-v2 uninstall contract for module-owned data outside migrations. */
+final readonly class Uninstall
+{
+    public function __construct(
+        /** @var class-string<DataCleanup> */
+        public string $dataCleanup,
+    ) {}
+
+    /** @param array<string, mixed> $value */
+    public static function fromArray(array $value, string $moduleName): self
+    {
+        $unknown = array_diff(array_keys($value), ['data_cleanup']);
+        if ($unknown !== []) {
+            throw new InvalidArgumentException("Module uninstall contract contains unsupported field '".reset($unknown)."'.");
+        }
+
+        $dataCleanup = $value['data_cleanup'] ?? null;
+        $prefix = 'Modules\\'.$moduleName.'\\';
+        if (! is_string($dataCleanup) || $dataCleanup === '' || ! str_starts_with($dataCleanup, $prefix)
+            || ! preg_match('/^Modules\\\\[A-Za-z][A-Za-z0-9]*(?:\\\\[A-Za-z][A-Za-z0-9]*)*$/', $dataCleanup)) {
+            throw new InvalidArgumentException("Module uninstall field 'data_cleanup' must be a class in the Modules\\{$moduleName} namespace.");
+        }
+
+        return new self($dataCleanup);
+    }
+
+    /** @return array{data_cleanup: class-string<DataCleanup>} */
+    public function toArray(): array
+    {
+        return ['data_cleanup' => $this->dataCleanup];
+    }
+}

--- a/stubs/composer.stub
+++ b/stubs/composer.stub
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.3",
         "ext-json": "*",
-        "invoiceshelf/modules": "^3.1"
+        "invoiceshelf/modules": "^3.2"
     },
     "require-dev": {
         "laravel/pint": "^1.16",

--- a/stubs/json.stub
+++ b/stubs/json.stub
@@ -10,21 +10,24 @@
     "aliases": {},
     "files": [],
     "requires": {},
-    "schema_version": 1,
+    "schema_version": 2,
     "slug": "$KEBAB_NAME$",
     "version": "0.1.0",
     "license": "AGPL-3.0-only",
     "compatibility": {
         "invoiceshelf": "^3.0.0",
-        "module_api": "^1.0.0",
+        "module_api": "^1.1.0",
         "php": "^8.3.0",
         "extensions": [
             "ext-json"
         ]
     },
     "module_dependencies": {},
-    "migration_policy": "forward-only",
+    "migration_policy": "reversible",
     "dependency_policy": "host-provided-only",
+    "uninstall": {
+        "data_cleanup": "$MODULE_NAMESPACE$\\$STUDLY_NAME$\\Providers\\$STUDLY_NAME$ServiceProvider"
+    },
     "assets": [
         "dist/module.js",
         "dist/module.css"

--- a/stubs/scaffold/provider.stub
+++ b/stubs/scaffold/provider.stub
@@ -3,10 +3,11 @@
 namespace $NAMESPACE$;
 
 use Illuminate\Support\Str;
+use InvoiceShelf\Modules\Contracts\DataCleanup;
 use InvoiceShelf\Modules\Registry as ModuleRegistry;
 use InvoiceShelf\Modules\Support\ModuleServiceProvider;
 
-class $CLASS$ extends ModuleServiceProvider
+class $CLASS$ extends ModuleServiceProvider implements DataCleanup
 {
     /**
      * The name of the module.
@@ -139,6 +140,17 @@ class $CLASS$ extends ModuleServiceProvider
         //         ['value' => 'model-b', 'label' => 'Model B'],
         //     ],
         // ]);
+    }
+
+    /**
+     * Remove module-owned data that is not covered by reversible migrations.
+     *
+     * This method is called during uninstall. Keep it idempotent: it may be
+     * retried after a failed uninstall, and throw if cleanup cannot complete.
+     */
+    public function cleanup(): void
+    {
+        // Delete external resources and module-owned records not handled by down() migrations.
     }
 
     /**

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -6,6 +6,8 @@ namespace InvoiceShelf\Modules\Tests;
 
 use InvalidArgumentException;
 use InvoiceShelf\Modules\Manifest\CanonicalJson;
+use InvoiceShelf\Modules\Manifest\CleanupValidator;
+use InvoiceShelf\Modules\Manifest\MigrationValidator;
 use InvoiceShelf\Modules\Manifest\ModuleManifest;
 use InvoiceShelf\Modules\Manifest\PackageValidator;
 use InvoiceShelf\Modules\Manifest\ReleaseEnvelope;
@@ -26,7 +28,7 @@ class ManifestTest extends TestCase
         $this->assertSame('AGPL-3.0-only', $stub['license']);
         $this->assertSame('^8.3', $stub['require']['php']);
         $this->assertSame('*', $stub['require']['ext-json']);
-        $this->assertSame('^3.1', $stub['require']['invoiceshelf/modules']);
+        $this->assertSame('^3.2', $stub['require']['invoiceshelf/modules']);
         $this->assertSame('^11.0', $stub['require-dev']['orchestra/testbench']);
         $this->assertSame('^12.0', $stub['require-dev']['phpunit/phpunit']);
         $this->assertSame('vendor/bin/pint --test', $stub['scripts']['lint']);
@@ -38,6 +40,23 @@ class ManifestTest extends TestCase
 
         $this->assertIsArray($replacements);
         $this->assertContains('KEBAB_NAME', $replacements);
+    }
+
+    public function test_schema_v2_stubs_declare_a_compatible_cleanup_provider(): void
+    {
+        $json = file_get_contents(dirname(__DIR__).'/stubs/json.stub');
+        $provider = file_get_contents(dirname(__DIR__).'/stubs/scaffold/provider.stub');
+
+        $this->assertIsString($json);
+        $this->assertIsString($provider);
+
+        $stub = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame(2, $stub['schema_version']);
+        $this->assertSame('^1.1.0', $stub['compatibility']['module_api']);
+        $this->assertSame('reversible', $stub['migration_policy']);
+        $this->assertSame('$MODULE_NAMESPACE$\\$STUDLY_NAME$\\Providers\\$STUDLY_NAME$ServiceProvider', $stub['uninstall']['data_cleanup']);
+        $this->assertStringContainsString('implements DataCleanup', $provider);
+        $this->assertStringContainsString('function cleanup(): void', $provider);
     }
 
     public function test_valid_module_manifest_is_normalized(): void
@@ -61,6 +80,15 @@ class ManifestTest extends TestCase
         $this->assertSame('^3.0', ModuleManifest::fromArray($manifest)->compatibility->invoiceshelf);
     }
 
+    public function test_schema_v2_module_manifest_requires_reversible_migrations_and_a_data_cleanup_class(): void
+    {
+        $manifest = ModuleManifest::fromArray($this->reversibleModuleManifest());
+
+        $this->assertSame('reversible', $manifest->migrationPolicy);
+        $this->assertSame('Modules\\SalesTaxUs\\Providers\\SalesTaxUsServiceProvider', $manifest->uninstall?->dataCleanup);
+        $this->assertSame($this->reversibleModuleManifest(), $manifest->toArray());
+    }
+
     #[DataProvider('invalidModuleManifests')]
     public function test_invalid_module_contracts_are_rejected(string $message, array $changes): void
     {
@@ -73,7 +101,7 @@ class ManifestTest extends TestCase
     /** @return iterable<string, array{string, array<string, mixed>}> */
     public static function invalidModuleManifests(): iterable
     {
-        yield 'unsupported schema' => ['schema_version=1', ['schema_version' => 2]];
+        yield 'unsupported schema' => ['schema_version=1 or schema_version=2', ['schema_version' => 3]];
         yield 'bad slug' => ['lowercase kebab-case', ['slug' => 'Sales Tax']];
         yield 'bad module name' => ['PascalCase', ['name' => 'sales_tax_us']];
         yield 'bad version' => ['SemVer', ['version' => 'v1.0']];
@@ -83,11 +111,30 @@ class ManifestTest extends TestCase
         yield 'bad extension' => ['ext-name', ['compatibility' => ['extensions' => ['json']]]];
         yield 'bad module dependency' => ['another lowercase kebab-case', ['module_dependencies' => ['sales-tax-us' => '^1.0.0']]];
         yield 'bad dependency range' => ['supported SemVer constraint', ['module_dependencies' => ['other-module' => 'dev-main']]];
-        yield 'rollback migration policy' => ['forward-only', ['migration_policy' => 'reversible']];
+        yield 'legacy rollback migration policy' => ['schema_version=1 requires migration_policy', ['migration_policy' => 'reversible']];
         yield 'runtime dependency policy' => ['host-provided-only', ['dependency_policy' => 'composer-install']];
         yield 'remote asset' => ['local dist', ['assets' => ['https://cdn.example.test/module.js']]];
         yield 'source asset' => ['local dist', ['assets' => ['resources/module.ts']]];
         yield 'unknown key' => ['unsupported field', ['composer_dependencies' => []]];
+    }
+
+    #[DataProvider('invalidSchemaV2ModuleManifests')]
+    public function test_invalid_schema_v2_module_contracts_are_rejected(string $message, array $changes): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        ModuleManifest::fromArray(array_replace_recursive($this->reversibleModuleManifest(), $changes));
+    }
+
+    /** @return iterable<string, array{string, array<string, mixed>}> */
+    public static function invalidSchemaV2ModuleManifests(): iterable
+    {
+        yield 'forward only v2 policy' => ['schema_version=2 requires migration_policy', ['migration_policy' => 'forward-only']];
+        yield 'missing uninstall contract' => ["must declare an 'uninstall' object", ['uninstall' => null]];
+        yield 'missing data cleanup class' => ['data_cleanup', ['uninstall' => ['data_cleanup' => '']]];
+        yield 'data cleanup outside module namespace' => ['Modules\\SalesTaxUs namespace', ['uninstall' => ['data_cleanup' => 'App\\Cleanup']]];
+        yield 'unknown uninstall key' => ['uninstall contract contains unsupported field', ['uninstall' => ['data_cleanup' => 'Modules\\SalesTaxUs\\Cleanup', 'command' => 'rm -rf']]];
     }
 
     public function test_canonical_json_sorts_objects_and_preserves_lists_exactly(): void
@@ -114,13 +161,15 @@ class ManifestTest extends TestCase
         ));
     }
 
-    public function test_package_validator_requires_built_assets_and_host_provided_composer_dependencies(): void
+    public function test_package_validator_requires_built_assets_host_provided_composer_dependencies_and_reversible_migrations(): void
     {
         $directory = sys_get_temp_dir().'/invoiceshelf-modules-'.bin2hex(random_bytes(8));
         mkdir($directory.'/dist', 0700, true);
 
         try {
-            file_put_contents($directory.'/module.json', json_encode($this->moduleManifest(), JSON_THROW_ON_ERROR));
+            mkdir($directory.'/database/migrations', 0700, true);
+            mkdir($directory.'/app/Providers', 0700, true);
+            file_put_contents($directory.'/module.json', json_encode($this->reversibleModuleManifest(), JSON_THROW_ON_ERROR));
             file_put_contents($directory.'/composer.json', json_encode([
                 'name' => 'invoiceshelf/module-sales-tax-us',
                 'license' => 'AGPL-3.0-only',
@@ -128,6 +177,8 @@ class ManifestTest extends TestCase
             ], JSON_THROW_ON_ERROR));
             file_put_contents($directory.'/dist/module.js', 'built javascript');
             file_put_contents($directory.'/dist/module.css', 'built css');
+            file_put_contents($directory.'/database/migrations/2026_01_01_000000_create_rates_table.php', $this->validMigration());
+            file_put_contents($directory.'/app/Providers/SalesTaxUsServiceProvider.php', $this->validCleanupProvider());
 
             $this->assertSame('sales-tax-us', PackageValidator::validate($directory)->slug);
 
@@ -154,7 +205,7 @@ class ManifestTest extends TestCase
             $this->expectExceptionMessage('missing');
             PackageValidator::validate($directory);
         } finally {
-            foreach (['module.json', 'composer.json', 'dist/module.js', 'dist/module.css'] as $file) {
+            foreach (['module.json', 'composer.json', 'dist/module.js', 'dist/module.css', 'database/migrations/2026_01_01_000000_create_rates_table.php', 'app/Providers/SalesTaxUsServiceProvider.php'] as $file) {
                 if (is_file($directory.'/'.$file)) {
                     unlink($directory.'/'.$file);
                 }
@@ -162,10 +213,253 @@ class ManifestTest extends TestCase
             if (is_dir($directory.'/dist')) {
                 rmdir($directory.'/dist');
             }
+            if (is_dir($directory.'/database/migrations')) {
+                rmdir($directory.'/database/migrations');
+            }
+            if (is_dir($directory.'/database')) {
+                rmdir($directory.'/database');
+            }
+            if (is_dir($directory.'/app/Providers')) {
+                rmdir($directory.'/app/Providers');
+            }
+            if (is_dir($directory.'/app')) {
+                rmdir($directory.'/app');
+            }
             if (is_dir($directory)) {
                 rmdir($directory);
             }
         }
+    }
+
+    #[DataProvider('invalidMigrations')]
+    public function test_reversible_migrations_must_have_public_non_empty_up_and_down_methods(string $source, string $message): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'invoiceshelf-module-migration-');
+        $this->assertNotFalse($path);
+        file_put_contents($path, $source);
+
+        try {
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage($message);
+            MigrationValidator::validateFile($path);
+        } finally {
+            unlink($path);
+        }
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function invalidMigrations(): iterable
+    {
+        yield 'missing down' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { public function up(): void { $value = 1; } };
+PHP,
+            'down(): void',
+        ];
+        yield 'protected up' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { protected function up(): void { $value = 1; } public function down(): void { $value = 1; } };
+PHP,
+            'up(): void',
+        ];
+        yield 'empty down' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { public function up(): void { $value = 1; } public function down(): void {} };
+PHP,
+            'down(): void',
+        ];
+        yield 'drop table in up' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { public function up(): void { Schema::dropIfExists('rates'); } public function down(): void { Schema::create('rates', fn () => null); } };
+PHP,
+            'Destructive calls are allowed only in down()',
+        ];
+        yield 'update data in up' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { public function up(): void { DB::table('rates')->update(['active' => false]); } public function down(): void { $value = 1; } };
+PHP,
+            'Destructive calls are allowed only in down()',
+        ];
+        yield 'rename in up' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { public function up(): void { Schema::rename('old', 'new'); } public function down(): void { $value = 1; } };
+PHP,
+            'Destructive calls are allowed only in down()',
+        ];
+        yield 'raw function in up' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { public function up(): void { raw('delete from rates'); } public function down(): void { $value = 1; } };
+PHP,
+            'Destructive calls are allowed only in down()',
+        ];
+        yield 'unprepared in up' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { public function up(): void { DB::unprepared('delete from rates'); } public function down(): void { $value = 1; } };
+PHP,
+            'Destructive calls are allowed only in down()',
+        ];
+        yield 'statement in up' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { public function up(): void { DB::statement('delete from rates'); } public function down(): void { $value = 1; } };
+PHP,
+            'Destructive calls are allowed only in down()',
+        ];
+        yield 'affecting statement in up' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { public function up(): void { DB::affectingStatement('delete from rates'); } public function down(): void { $value = 1; } };
+PHP,
+            'Destructive calls are allowed only in down()',
+        ];
+        yield 'static up' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { public static function up(): void { $value = 1; } public function down(): void { $value = 1; } };
+PHP,
+            'up(): void',
+        ];
+        yield 'up with argument' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { public function up(string $table): void { $value = 1; } public function down(): void { $value = 1; } };
+PHP,
+            'up(): void',
+        ];
+        yield 'non-void down' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { public function up(): void { $value = 1; } public function down(): bool { return true; } };
+PHP,
+            'down(): void',
+        ];
+        yield 'multiple migration classes' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+return new class extends Migration { public function up(): void { $value = 1; } public function down(): void { $value = 1; } };
+class AnotherMigration extends Migration { public function up(): void { $value = 1; } public function down(): void { $value = 1; } }
+PHP,
+            'exactly one concrete Laravel migration class',
+        ];
+        yield 'not a Laravel migration' => [
+            <<<'PHP'
+<?php
+return new class { public function up(): void { $value = 1; } public function down(): void { $value = 1; } };
+PHP,
+            'must extend Illuminate\\Database\\Migrations\\Migration',
+        ];
+        yield 'abstract migration' => [
+            <<<'PHP'
+<?php
+use Illuminate\Database\Migrations\Migration;
+abstract class SalesTaxMigration extends Migration { public function up(): void { $value = 1; } public function down(): void { $value = 1; } }
+PHP,
+            'and be concrete',
+        ];
+    }
+
+    public function test_reversible_migrations_allow_destructive_calls_in_down(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'invoiceshelf-module-migration-');
+        $this->assertNotFalse($path);
+        file_put_contents($path, $this->validMigration());
+
+        try {
+            MigrationValidator::validateFile($path);
+            $this->addToAssertionCount(1);
+        } finally {
+            unlink($path);
+        }
+    }
+
+    #[DataProvider('invalidCleanupProviders')]
+    public function test_cleanup_class_must_be_concrete_and_implement_the_public_contract(string $source, string $message): void
+    {
+        $directory = sys_get_temp_dir().'/invoiceshelf-modules-cleanup-'.bin2hex(random_bytes(8));
+        mkdir($directory.'/app/Providers', 0700, true);
+        file_put_contents($directory.'/app/Providers/SalesTaxUsServiceProvider.php', $source);
+
+        try {
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage($message);
+            CleanupValidator::validateDirectory($directory, 'Modules\\SalesTaxUs\\Providers\\SalesTaxUsServiceProvider');
+        } finally {
+            unlink($directory.'/app/Providers/SalesTaxUsServiceProvider.php');
+            rmdir($directory.'/app/Providers');
+            rmdir($directory.'/app');
+            rmdir($directory);
+        }
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function invalidCleanupProviders(): iterable
+    {
+        yield 'missing interface' => [
+            <<<'PHP'
+<?php
+namespace Modules\SalesTaxUs\Providers;
+final class SalesTaxUsServiceProvider { public function cleanup(): void {} }
+PHP,
+            'must implement',
+        ];
+        yield 'abstract class' => [
+            <<<'PHP'
+<?php
+namespace Modules\SalesTaxUs\Providers;
+use InvoiceShelf\Modules\Contracts\DataCleanup;
+abstract class SalesTaxUsServiceProvider implements DataCleanup { public function cleanup(): void {} }
+PHP,
+            'must not be abstract',
+        ];
+        yield 'abstract cleanup method' => [
+            <<<'PHP'
+<?php
+namespace Modules\SalesTaxUs\Providers;
+use InvoiceShelf\Modules\Contracts\DataCleanup;
+abstract class SalesTaxUsServiceProvider implements DataCleanup { abstract public function cleanup(): void; }
+PHP,
+            'concrete public zero-argument cleanup(): void',
+        ];
+        yield 'static cleanup method' => [
+            <<<'PHP'
+<?php
+namespace Modules\SalesTaxUs\Providers;
+use InvoiceShelf\Modules\Contracts\DataCleanup;
+final class SalesTaxUsServiceProvider implements DataCleanup { public static function cleanup(): void {} }
+PHP,
+            'concrete public zero-argument cleanup(): void',
+        ];
+        yield 'cleanup with argument' => [
+            <<<'PHP'
+<?php
+namespace Modules\SalesTaxUs\Providers;
+use InvoiceShelf\Modules\Contracts\DataCleanup;
+final class SalesTaxUsServiceProvider implements DataCleanup { public function cleanup(string $scope): void {} }
+PHP,
+            'concrete public zero-argument cleanup(): void',
+        ];
     }
 
     public function test_valid_stable_release_has_deterministic_canonical_form(): void
@@ -355,6 +649,56 @@ class ManifestTest extends TestCase
             'dependency_policy' => 'host-provided-only',
             'assets' => ['dist/module.js', 'dist/module.css'],
         ];
+    }
+
+    /** @return array<string, mixed> */
+    private function reversibleModuleManifest(): array
+    {
+        return [
+            ...$this->moduleManifest(),
+            'schema_version' => 2,
+            'migration_policy' => 'reversible',
+            'uninstall' => [
+                'data_cleanup' => 'Modules\\SalesTaxUs\\Providers\\SalesTaxUsServiceProvider',
+            ],
+        ];
+    }
+
+    private function validMigration(): string
+    {
+        return <<<'PHP'
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('rates', function (): void {});
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rates');
+    }
+};
+PHP;
+    }
+
+    private function validCleanupProvider(): string
+    {
+        return <<<'PHP'
+<?php
+
+namespace Modules\SalesTaxUs\Providers;
+
+use InvoiceShelf\Modules\Contracts\DataCleanup;
+
+final class SalesTaxUsServiceProvider implements DataCleanup
+{
+    public function cleanup(): void {}
+}
+PHP;
     }
 
     /** @return array<string, mixed> */


### PR DESCRIPTION
## Summary

- introduce the schema-v2 reversible uninstall manifest contract
- add the `DataCleanup` developer hook for non-migration resources
- validate cleanup handlers and reversible Laravel migrations with PHP-Parser
- update module stubs and documentation for SDK 3.2

## Uninstall contract

The module developer owns an idempotent `cleanup()` implementation and the `down()` method for each module migration. The host application owns orchestration in this order:

1. run the developer cleanup hook
2. reset every module migration batch in reverse order
3. remove host-owned module settings

Schema-v1 packages remain supported as code-only uninstall packages.

## Validation

- `composer test` — 101 tests, 252 assertions
- `composer lint`
- `composer validate --strict --no-check-publish`
- `git diff --check`

## Release

After merging, tag this commit as `3.2.0`. The InvoiceShelf v3 and HelloWorld rollout PRs intentionally depend on that tag.
