### PR TITLE
docs: point AI modules at platform contracts

### DIFF
--- a/stubs/scaffold/provider.stub
+++ b/stubs/scaffold/provider.stub
@@ -121,7 +121,7 @@ class $CLASS$ extends ModuleServiceProvider implements DataCleanup
         // -------------------------------------------------------------------
         // Custom AI driver — uncomment if your module ships one.
         //
-        // The driver class must extend App\Support\Ai\AiDriver and implement
+        // The driver class must extend App\Platform\Ai\Contracts\AiDriver and implement
         // chatCompletion(), textCompletion(), and validateConnection(). The
         // host's AI configuration UI will pick up `label`, `website`,
         // `supported_roles`, `suggested_models`, and any `config_fields`.

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -59,6 +59,15 @@ class ManifestTest extends TestCase
         $this->assertStringContainsString('function cleanup(): void', $provider);
     }
 
+    public function test_provider_stub_uses_the_public_platform_ai_driver_contract(): void
+    {
+        $provider = file_get_contents(dirname(__DIR__).'/stubs/scaffold/provider.stub');
+
+        $this->assertIsString($provider);
+        $this->assertStringContainsString('App\\Platform\\Ai\\Contracts\\AiDriver', $provider);
+        $this->assertStringNotContainsString('App\\Support\\Ai\\AiDriver', $provider);
+    }
+
     public function test_valid_module_manifest_is_normalized(): void
     {
         $manifest = ModuleManifest::fromArray($this->moduleManifest());


### PR DESCRIPTION
## Summary

- updates the module SDK AI extension example to import the v3 AI contract from its new Platform namespace
- keeps extension documentation aligned with the modular domain architecture refactor in the main application

## Validation

Documentation-only namespace update; the InvoiceShelf module test suite passes against the companion application branch.
