### PR TITLE
feat: publish AI module contracts

### DIFF
--- a/.github/workflows/module-release.yml
+++ b/.github/workflows/module-release.yml
@@ -60,13 +60,13 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: sodium
           coverage: none
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install and verify source
         run: |

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ The SDK remains MIT. Official first-party modules are separate repositories and 
   - A sidebar entry (title, link, icon) that the host app renders in the company sidebar's "Modules" group.
   - A settings schema (sections of typed fields) that the host app renders generically as a form via `BaseSchemaForm.vue`, with values stored per-company.
 - **`InvoiceShelf\Modules\Settings\Schema` / `FieldType`** — a value object + enum that lock down the supported field types (`text`, `password`, `textarea`, `switch`, `number`, `select`, `multiselect`) and validate the schema shape at registration time.
+- **`InvoiceShelf\Modules\Ai`** — framework-neutral AI provider contracts for module drivers: extend `Ai\Contracts\AiDriver`, return `Ai\Data\AiChatResponse` from chat completions, and throw `Ai\Exceptions\AiException` for provider failures.
+- **`InvoiceShelf\Modules\Contracts\Host`** — host boundaries for global/company settings, company-scoped authorization, and the AI assistant's twelve read-only company-data queries. These expose only scalar values and arrays, never Laravel or application models.
+- **`frontend/index.d.ts`** — the versioned TypeScript contract for module-contributed UI surfaces, authenticated HTTP access, translations, notifications, and host lifecycle events. Module builds consume it as a type-only dependency from the Composer-installed SDK.
 
 The actual module loading, file generation, migration, and provider registration are all handled by upstream `nwidart/laravel-modules` (required as a composer dependency).
 
@@ -36,7 +39,7 @@ An official module lives in its own repository and Composer package — never in
   "requires": {},
   "compatibility": {
     "invoiceshelf": "^3.0.0",
-    "module_api": "^1.1.0",
+    "module_api": "^1.2.0",
     "php": "^8.3.0",
     "extensions": ["ext-json"]
   },
@@ -69,6 +72,16 @@ final class SalesTaxUsCleanup implements DataCleanup
 `cleanup()` must be idempotent because uninstall may be retried; an exception signals failure and must stop the uninstall. Its body may intentionally be empty for a no-op cleanup, but its class must be concrete and its method must be a non-static, non-abstract, zero-argument public `cleanup(): void` implementation. During uninstall, the host calls this developer cleanup first while module tables still exist, then runs every migration's `down()` method, and finally removes host-owned module settings. The scaffold uses its generated service provider as the default cleanup class purely for convenience. Modules may instead point `uninstall.data_cleanup` to a dedicated class in their own namespace.
 
 At runtime, `Registry::registerScript()` and `Registry::registerStyle()` accept only existing local `.js` and `.css` files (for example `module_path($name, 'dist/module.js')`). The registry stores the canonical real path and rejects URLs, missing files, and incorrect extensions; modules cannot inject remote scripts or styles.
+
+## AI module contracts
+
+AI drivers are SDK contracts, not `App\Platform` contracts. A module driver extends `InvoiceShelf\Modules\Ai\Contracts\AiDriver`; its constructor receives an API key and provider configuration, it implements chat completion, text completion, and connection validation, and it may override `listModels()`. Chat completions return `InvoiceShelf\Modules\Ai\Data\AiChatResponse`; provider failures use `InvoiceShelf\Modules\Ai\Exceptions\AiException`, whose `errorKey` is safe for the host UI to localize.
+
+Register a driver with `Registry::registerAiDriver()`. The identifier is stable and unique among AI drivers. Metadata requires a concrete SDK `AiDriver` class, a non-empty label, a non-empty unique `supported_roles` list (`chat` and/or `text_generation`), a list of `{value, label}` suggested models, and a `config_fields` array. `website` and `default_base_url` are optional strings. Generic `registerDriver()` retains its existing permissive behavior for non-AI driver categories.
+
+Modules that need host data depend on the narrow interfaces under `InvoiceShelf\Modules\Contracts\Host`: `SettingsStore` has global and per-company get/put/delete operations plus a cleanup-only operation that removes one key from every company, `ModuleAuthorization` evaluates a user/company ability against the stable `customer`, `invoice`, `expense`, `payment`, or `item` resource string (or `null` for dashboard-like abilities), and `CompanyDataReader` covers the assistant's twelve current read-only query use cases. The host owns the implementations and binds them; modules must not import application models or Laravel collections through these interfaces.
+
+Frontend modules import `InvoiceShelfExtensionApi` and its contribution types from the Composer-installed `frontend/index.d.ts` as a type-only build dependency. The host passes that API as the third argument to `window.InvoiceShelf.booting()`. Runtime contributions remain on the host's Vue, router, Axios, i18n, and notification instances; the declaration file does not bundle a second frontend framework runtime.
 
 ## Signed releases
 

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -1,0 +1,75 @@
+import type { AxiosInstance } from 'axios'
+import type { Component } from 'vue'
+import type { RouteLocationRaw, Router } from 'vue-router'
+
+export type ExtensionVisibilityPredicate = () => boolean
+
+export interface ExtensionContribution {
+  /** A module-stable identifier. Registering the same id replaces the prior contribution. */
+  id: string
+  /** Lower values render first. Defaults to 100. */
+  priority?: number
+  /** Return false to omit this contribution without unregistering it. */
+  visible?: ExtensionVisibilityPredicate
+}
+
+export interface ComponentExtensionContribution extends ExtensionContribution {
+  component: Component
+  props?: Record<string, unknown>
+}
+
+export interface RichEditorContext {
+  getHtml(): string
+  insertContent(content: string): void
+  replaceContent(content: string): void
+}
+
+export interface SettingsNavigationContribution extends ExtensionContribution {
+  title: string
+  icon: string
+  to: RouteLocationRaw
+}
+
+export interface SettingsPageContribution
+  extends Omit<SettingsNavigationContribution, 'to'> {
+  /** A child path below the relevant settings route, without a leading slash. */
+  path: string
+  component: Component
+  meta?: Record<string, unknown>
+}
+
+export interface BootstrapCompletedEvent {
+  adminMode: boolean
+  companyId: number | null
+}
+
+export interface CompanyChangeEvent {
+  previousCompanyId: number | null
+  companyId: number | null
+}
+
+export interface InvoiceShelfExtensionEvents {
+  'bootstrap:completed': BootstrapCompletedEvent
+  'company:changing': CompanyChangeEvent
+  'company:changed': CompanyChangeEvent
+}
+
+export interface InvoiceShelfExtensionApi {
+  readonly client: AxiosInstance
+  readonly router: Router
+  registerHeaderAction(contribution: ComponentExtensionContribution): () => void
+  registerCompanyLayoutOverlay(contribution: ComponentExtensionContribution): () => void
+  registerRichEditorToolbarAction(contribution: ComponentExtensionContribution): () => void
+  registerCompanySettingsNavigation(contribution: SettingsNavigationContribution): () => void
+  registerAdminSettingsNavigation(contribution: SettingsNavigationContribution): () => void
+  registerCompanySettingsPage(contribution: SettingsPageContribution): () => void
+  registerAdminSettingsPage(contribution: SettingsPageContribution): () => void
+  addMessages(messages: Record<string, Record<string, unknown>>): void
+  notify(type: 'success' | 'error' | 'warning' | 'info', message: string): void
+  on<EventName extends keyof InvoiceShelfExtensionEvents>(
+    event: EventName,
+    listener: (payload: InvoiceShelfExtensionEvents[EventName]) => void,
+  ): () => void
+  /** Remove all registered UI and dynamically-added routes. Useful before a host reload. */
+  reset(): void
+}

--- a/src/Ai/Contracts/AiDriver.php
+++ b/src/Ai/Contracts/AiDriver.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Ai\Contracts;
+
+use InvoiceShelf\Modules\Ai\Data\AiChatResponse;
+use InvoiceShelf\Modules\Ai\Exceptions\AiException;
+
+/**
+ * Provider-neutral contract for AI providers contributed by modules.
+ */
+abstract class AiDriver
+{
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public function __construct(
+        protected string $apiKey,
+        protected array $config = [],
+    ) {}
+
+    /**
+     * @param  array<int, array<string, mixed>>  $messages  OpenAI chat-message format.
+     * @param  array<int, array<string, mixed>>  $tools  OpenAI tools schema array.
+     * @param  array<string, mixed>  $options  Provider-specific options.
+     *
+     * @throws AiException
+     */
+    abstract public function chatCompletion(
+        array $messages,
+        string $model,
+        array $tools = [],
+        array $options = [],
+    ): AiChatResponse;
+
+    /**
+     * @param  array<string, mixed>  $options  Provider-specific options.
+     *
+     * @throws AiException
+     */
+    abstract public function textCompletion(
+        string $prompt,
+        string $model,
+        array $options = [],
+    ): string;
+
+    /**
+     * @return array<string, mixed> Provider information suitable for the configuration UI.
+     *
+     * @throws AiException
+     */
+    abstract public function validateConnection(): array;
+
+    /**
+     * @return array<int, array{value: string, label: string}>
+     */
+    public function listModels(): array
+    {
+        return [];
+    }
+}

--- a/src/Ai/Data/AiChatResponse.php
+++ b/src/Ai/Data/AiChatResponse.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Ai\Data;
+
+/**
+ * Provider-agnostic chat completion response modelled after OpenAI's shape.
+ */
+class AiChatResponse
+{
+    /**
+     * @param  string|null  $message  Null for a tool-call-only turn.
+     * @param  array<int, array{id: string, name: string, arguments: array<string, mixed>}>  $toolCalls
+     * @param  array{tokens_in?: int, tokens_out?: int}  $usage
+     */
+    public function __construct(
+        public readonly ?string $message,
+        public readonly array $toolCalls = [],
+        public readonly string $finishReason = 'stop',
+        public readonly array $usage = [],
+        public readonly ?string $model = null,
+    ) {}
+
+    public function hasToolCalls(): bool
+    {
+        return $this->toolCalls !== [];
+    }
+}

--- a/src/Ai/Exceptions/AiException.php
+++ b/src/Ai/Exceptions/AiException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Ai\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * AI driver failure with a stable error key for presentation layers.
+ */
+class AiException extends RuntimeException
+{
+    public function __construct(
+        string $message,
+        public readonly string $errorKey = 'server_error',
+        int $code = 0,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Contracts/Host/CompanyDataReader.php
+++ b/src/Contracts/Host/CompanyDataReader.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Contracts\Host;
+
+/**
+ * Read-only company data required by the AI assistant's twelve built-in queries.
+ *
+ * Returned values are arrays of scalar data only. Hosts must not expose ORM
+ * models, collections, or framework-specific value objects across this boundary.
+ */
+interface CompanyDataReader
+{
+    /** @return array<string, mixed> */
+    public function companyStats(int $companyId, string $startDate, string $endDate): array;
+
+    /** @return array<string, mixed>|null */
+    public function findCustomer(int $companyId, int $customerId): ?array;
+
+    /** @return array<string, mixed> */
+    public function searchCustomers(int $companyId, ?string $query, int $limit): array;
+
+    /** @return array<string, mixed> */
+    public function rankCustomers(int $companyId, string $metric, ?string $startDate, ?string $endDate, int $limit): array;
+
+    /** @return array<string, mixed>|null */
+    public function findInvoice(int $companyId, string $invoiceNumber): ?array;
+
+    /** @return array<string, mixed> */
+    public function searchInvoices(
+        int $companyId,
+        ?string $query,
+        ?string $status,
+        ?int $customerId,
+        int $limit,
+    ): array;
+
+    /** @return array<string, mixed> */
+    public function overdueInvoices(int $companyId, int $limit): array;
+
+    /** @return array<string, mixed> */
+    public function recentPayments(int $companyId, string $startDate, int $limit): array;
+
+    /** @return array<string, mixed> */
+    public function expenseCategories(int $companyId): array;
+
+    /** @return array<string, mixed> */
+    public function rankExpenseCategories(int $companyId, ?string $startDate, ?string $endDate, int $limit): array;
+
+    /** @return array<string, mixed> */
+    public function searchItems(int $companyId, ?string $query, int $limit): array;
+
+    /** @return array<string, mixed> */
+    public function rankItems(int $companyId, string $metric, ?string $startDate, ?string $endDate, int $limit): array;
+}

--- a/src/Contracts/Host/ModuleAuthorization.php
+++ b/src/Contracts/Host/ModuleAuthorization.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Contracts\Host;
+
+/**
+ * Authorizes a user within a company without exposing host user or model types.
+ */
+interface ModuleAuthorization
+{
+    /**
+     * $resource is one of the stable host-defined identifiers `customer`,
+     * `invoice`, `expense`, `payment`, or `item`, or null for a dashboard-like
+     * ability that has no resource.
+     */
+    public function allows(int $userId, int $companyId, string $ability, ?string $resource = null): bool;
+}

--- a/src/Contracts/Host/SettingsStore.php
+++ b/src/Contracts/Host/SettingsStore.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Contracts\Host;
+
+/**
+ * Host-owned settings boundary for module configuration.
+ */
+interface SettingsStore
+{
+    public function getGlobal(string $key, mixed $default = null): mixed;
+
+    public function putGlobal(string $key, mixed $value): void;
+
+    public function deleteGlobal(string $key): void;
+
+    public function getCompany(int $companyId, string $key, mixed $default = null): mixed;
+
+    public function putCompany(int $companyId, string $key, mixed $value): void;
+
+    public function deleteCompany(int $companyId, string $key): void;
+
+    /** Delete one module-owned setting key for every company. */
+    public function deleteCompanyForAll(string $key): void;
+}

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace InvoiceShelf\Modules;
 
 use InvalidArgumentException;
+use InvoiceShelf\Modules\Ai\Contracts\AiDriver;
 use InvoiceShelf\Modules\Settings\Schema;
 
 /**
@@ -267,11 +268,74 @@ class Registry
      *         ],
      *     ]);
      *
-     * @param  array<string, mixed>  $meta
+     * @param  array{class: class-string<AiDriver>, label: string, supported_roles: non-empty-list<'chat'|'text_generation'>, suggested_models: list<array{value: string, label: string}>, config_fields: array<mixed>, website?: string, default_base_url?: string}  $meta
      */
     public static function registerAiDriver(string $name, array $meta): void
     {
+        self::validateAiDriver($name, $meta);
+
+        if ((static::$drivers['ai'][$name] ?? null) === $meta) {
+            return;
+        }
+
+        if (isset(static::$drivers['ai'][$name])) {
+            throw new InvalidArgumentException("AI driver '{$name}' is already registered.");
+        }
+
         static::registerDriver('ai', $name, $meta);
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     *
+     * @throws InvalidArgumentException
+     */
+    private static function validateAiDriver(string $name, array $meta): void
+    {
+        if (! preg_match('/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/', $name)) {
+            throw new InvalidArgumentException('AI driver name must be a stable, non-empty identifier using letters, numbers, dots, underscores, or hyphens.');
+        }
+
+        $class = $meta['class'] ?? null;
+        if (! is_string($class) || ! class_exists($class) || ! is_subclass_of($class, AiDriver::class) || (new \ReflectionClass($class))->isAbstract()) {
+            throw new InvalidArgumentException('AI driver class must be a concrete class extending '.AiDriver::class.'.');
+        }
+
+        if (! is_string($meta['label'] ?? null) || trim($meta['label']) === '') {
+            throw new InvalidArgumentException('AI driver label must be a non-empty string.');
+        }
+
+        $roles = $meta['supported_roles'] ?? null;
+        if (! is_array($roles) || ! array_is_list($roles) || $roles === [] || count($roles) !== count(array_unique($roles, SORT_REGULAR))) {
+            throw new InvalidArgumentException("AI driver supported_roles must be a non-empty unique list containing only 'chat' and 'text_generation'.");
+        }
+        foreach ($roles as $role) {
+            if (! is_string($role) || ! in_array($role, ['chat', 'text_generation'], true)) {
+                throw new InvalidArgumentException("AI driver supported_roles must be a non-empty unique list containing only 'chat' and 'text_generation'.");
+            }
+        }
+
+        foreach (['website', 'default_base_url'] as $field) {
+            if (array_key_exists($field, $meta) && ! is_string($meta[$field])) {
+                throw new InvalidArgumentException("AI driver {$field} must be a string when provided.");
+            }
+        }
+
+        $models = $meta['suggested_models'] ?? null;
+        if (! is_array($models) || ! array_is_list($models)) {
+            throw new InvalidArgumentException('AI driver suggested_models must be a list of {value, label} entries.');
+        }
+        foreach ($models as $model) {
+            if (! is_array($model) || count($model) !== 2 || ! array_key_exists('value', $model) || ! array_key_exists('label', $model)
+                || ! is_string($model['value']) || trim($model['value']) === ''
+                || ! is_string($model['label']) || trim($model['label']) === '') {
+                throw new InvalidArgumentException('Each AI driver suggested_models entry must contain non-empty string value and label fields only.');
+            }
+        }
+
+        if (! is_array($meta['config_fields'] ?? null)) {
+            throw new InvalidArgumentException('AI driver config_fields must be an array.');
+        }
     }
 
     /**

--- a/stubs/composer.stub
+++ b/stubs/composer.stub
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.3",
         "ext-json": "*",
-        "invoiceshelf/modules": "^3.2"
+        "invoiceshelf/modules": "^3.3"
     },
     "require-dev": {
         "laravel/pint": "^1.16",

--- a/stubs/json.stub
+++ b/stubs/json.stub
@@ -16,7 +16,7 @@
     "license": "AGPL-3.0-only",
     "compatibility": {
         "invoiceshelf": "^3.0.0",
-        "module_api": "^1.1.0",
+        "module_api": "^1.2.0",
         "php": "^8.3.0",
         "extensions": [
             "ext-json"

--- a/stubs/scaffold/provider.stub
+++ b/stubs/scaffold/provider.stub
@@ -121,7 +121,7 @@ class $CLASS$ extends ModuleServiceProvider implements DataCleanup
         // -------------------------------------------------------------------
         // Custom AI driver — uncomment if your module ships one.
         //
-        // The driver class must extend App\Platform\Ai\Contracts\AiDriver and implement
+        // The driver class must extend InvoiceShelf\Modules\Ai\Contracts\AiDriver and implement
         // chatCompletion(), textCompletion(), and validateConnection(). The
         // host's AI configuration UI will pick up `label`, `website`,
         // `supported_roles`, `suggested_models`, and any `config_fields`.

--- a/tests/AiContractsTest.php
+++ b/tests/AiContractsTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InvoiceShelf\Modules\Tests;
+
+use InvoiceShelf\Modules\Ai\Contracts\AiDriver;
+use InvoiceShelf\Modules\Ai\Data\AiChatResponse;
+use InvoiceShelf\Modules\Ai\Exceptions\AiException;
+use InvoiceShelf\Modules\Contracts\Host\CompanyDataReader;
+use InvoiceShelf\Modules\Contracts\Host\ModuleAuthorization;
+use InvoiceShelf\Modules\Contracts\Host\SettingsStore;
+use ReflectionMethod;
+use RuntimeException;
+
+class AiContractsTest extends TestCase
+{
+    public function test_chat_response_preserves_its_provider_neutral_shape(): void
+    {
+        $response = new AiChatResponse(
+            message: null,
+            toolCalls: [['id' => 'call_1', 'name' => 'search_invoices', 'arguments' => ['query' => 'overdue']]],
+            finishReason: 'tool_calls',
+            usage: ['tokens_in' => 10, 'tokens_out' => 20],
+            model: 'provider/model',
+        );
+
+        $this->assertTrue($response->hasToolCalls());
+        $this->assertNull($response->message);
+        $this->assertSame('tool_calls', $response->finishReason);
+        $this->assertSame(['tokens_in' => 10, 'tokens_out' => 20], $response->usage);
+        $this->assertSame('provider/model', $response->model);
+        $this->assertFalse((new AiChatResponse('Done'))->hasToolCalls());
+    }
+
+    public function test_ai_exception_exposes_a_stable_error_key_and_previous_exception(): void
+    {
+        $previous = new RuntimeException('network failure');
+        $exception = new AiException('Unable to reach provider', 'invalid_api_key', 401, $previous);
+
+        $this->assertSame('invalid_api_key', $exception->errorKey);
+        $this->assertSame(401, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+        $this->assertSame('server_error', (new AiException('failed'))->errorKey);
+    }
+
+    public function test_ai_driver_constructor_and_default_model_list_are_available_to_concrete_drivers(): void
+    {
+        $driver = new ContractTestAiDriver('secret', ['base_url' => 'https://provider.test']);
+
+        $this->assertSame('secret', $driver->key());
+        $this->assertSame(['base_url' => 'https://provider.test'], $driver->driverConfig());
+        $this->assertSame([], $driver->listModels());
+        $this->assertSame('response', $driver->textCompletion('prompt', 'model'));
+        $this->assertSame('response', $driver->chatCompletion([], 'model')->message);
+        $this->assertSame(['connected' => true], $driver->validateConnection());
+    }
+
+    public function test_host_contracts_expose_the_exact_framework_neutral_ai_boundary(): void
+    {
+        $this->assertSame(
+            ['getGlobal', 'putGlobal', 'deleteGlobal', 'getCompany', 'putCompany', 'deleteCompany', 'deleteCompanyForAll'],
+            array_map(static fn (ReflectionMethod $method): string => $method->getName(), (new \ReflectionClass(SettingsStore::class))->getMethods()),
+        );
+        $this->assertSame('allows', (new \ReflectionClass(ModuleAuthorization::class))->getMethod('allows')->getName());
+        $this->assertSame(
+            [
+                'companyStats', 'findCustomer', 'searchCustomers', 'rankCustomers', 'findInvoice', 'searchInvoices',
+                'overdueInvoices', 'recentPayments', 'expenseCategories', 'rankExpenseCategories', 'searchItems', 'rankItems',
+            ],
+            array_map(static fn (ReflectionMethod $method): string => $method->getName(), (new \ReflectionClass(CompanyDataReader::class))->getMethods()),
+        );
+
+        $authorization = new ReflectionMethod(ModuleAuthorization::class, 'allows');
+        $this->assertSame('int', $authorization->getParameters()[0]->getType()?->getName());
+        $this->assertSame('int', $authorization->getParameters()[1]->getType()?->getName());
+        $this->assertSame('string', $authorization->getParameters()[2]->getType()?->getName());
+        $this->assertTrue($authorization->getParameters()[3]->getType()?->allowsNull());
+
+        foreach ((new \ReflectionClass(CompanyDataReader::class))->getMethods() as $method) {
+            $this->assertSame('array', $method->getReturnType()?->getName());
+        }
+        $this->assertTrue((new ReflectionMethod(CompanyDataReader::class, 'findCustomer'))->getReturnType()?->allowsNull());
+        $this->assertTrue((new ReflectionMethod(CompanyDataReader::class, 'findInvoice'))->getReturnType()?->allowsNull());
+    }
+}
+
+class ContractTestAiDriver extends AiDriver
+{
+    public function key(): string
+    {
+        return $this->apiKey;
+    }
+
+    /** @return array<string, mixed> */
+    public function driverConfig(): array
+    {
+        return $this->config;
+    }
+
+    public function chatCompletion(array $messages, string $model, array $tools = [], array $options = []): AiChatResponse
+    {
+        return new AiChatResponse('response');
+    }
+
+    public function textCompletion(string $prompt, string $model, array $options = []): string
+    {
+        return 'response';
+    }
+
+    public function validateConnection(): array
+    {
+        return ['connected' => true];
+    }
+}

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -28,7 +28,7 @@ class ManifestTest extends TestCase
         $this->assertSame('AGPL-3.0-only', $stub['license']);
         $this->assertSame('^8.3', $stub['require']['php']);
         $this->assertSame('*', $stub['require']['ext-json']);
-        $this->assertSame('^3.2', $stub['require']['invoiceshelf/modules']);
+        $this->assertSame('^3.3', $stub['require']['invoiceshelf/modules']);
         $this->assertSame('^11.0', $stub['require-dev']['orchestra/testbench']);
         $this->assertSame('^12.0', $stub['require-dev']['phpunit/phpunit']);
         $this->assertSame('vendor/bin/pint --test', $stub['scripts']['lint']);
@@ -52,20 +52,32 @@ class ManifestTest extends TestCase
 
         $stub = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
         $this->assertSame(2, $stub['schema_version']);
-        $this->assertSame('^1.1.0', $stub['compatibility']['module_api']);
+        $this->assertSame('^1.2.0', $stub['compatibility']['module_api']);
         $this->assertSame('reversible', $stub['migration_policy']);
         $this->assertSame('$MODULE_NAMESPACE$\\$STUDLY_NAME$\\Providers\\$STUDLY_NAME$ServiceProvider', $stub['uninstall']['data_cleanup']);
         $this->assertStringContainsString('implements DataCleanup', $provider);
         $this->assertStringContainsString('function cleanup(): void', $provider);
     }
 
-    public function test_provider_stub_uses_the_public_platform_ai_driver_contract(): void
+    public function test_provider_stub_uses_the_public_sdk_ai_driver_contract(): void
     {
         $provider = file_get_contents(dirname(__DIR__).'/stubs/scaffold/provider.stub');
 
         $this->assertIsString($provider);
-        $this->assertStringContainsString('App\\Platform\\Ai\\Contracts\\AiDriver', $provider);
-        $this->assertStringNotContainsString('App\\Support\\Ai\\AiDriver', $provider);
+        $this->assertStringContainsString('InvoiceShelf\\Modules\\Ai\\Contracts\\AiDriver', $provider);
+        $this->assertStringNotContainsString('App\\Platform\\Ai\\Contracts\\AiDriver', $provider);
+    }
+
+    public function test_sdk_publishes_the_typed_frontend_extension_contract(): void
+    {
+        $types = file_get_contents(dirname(__DIR__).'/frontend/index.d.ts');
+
+        $this->assertIsString($types);
+        $this->assertStringContainsString('interface InvoiceShelfExtensionApi', $types);
+        $this->assertStringContainsString('registerHeaderAction', $types);
+        $this->assertStringContainsString('registerRichEditorToolbarAction', $types);
+        $this->assertStringContainsString('registerCompanySettingsPage', $types);
+        $this->assertStringContainsString("'company:changed'", $types);
     }
 
     public function test_valid_module_manifest_is_normalized(): void

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace InvoiceShelf\Modules\Tests;
 
 use InvalidArgumentException;
+use InvoiceShelf\Modules\Ai\Contracts\AiDriver;
+use InvoiceShelf\Modules\Ai\Data\AiChatResponse;
 use InvoiceShelf\Modules\Registry;
 use InvoiceShelf\Modules\Settings\Schema;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -308,14 +310,16 @@ class RegistryTest extends TestCase
         Registry::flushDrivers();
 
         Registry::registerAiDriver('fake_ai_provider', [
-            'class' => 'FakeAiDriver',
+            'class' => FakeAiDriver::class,
             'label' => 'fake.ai.label',
             'supported_roles' => ['chat', 'text_generation'],
+            'suggested_models' => [['value' => 'fake-model', 'label' => 'Fake model']],
+            'config_fields' => [],
         ]);
 
         $meta = Registry::driverMeta('ai', 'fake_ai_provider');
         $this->assertNotNull($meta);
-        $this->assertSame('FakeAiDriver', $meta['class']);
+        $this->assertSame(FakeAiDriver::class, $meta['class']);
         $this->assertSame(['chat', 'text_generation'], $meta['supported_roles']);
     }
 
@@ -324,10 +328,93 @@ class RegistryTest extends TestCase
         Registry::flushDrivers();
 
         Registry::registerExchangeRateDriver('shared_name', ['class' => 'RateDriver', 'label' => 'rate']);
-        Registry::registerAiDriver('shared_name', ['class' => 'AiDriver',   'label' => 'ai']);
+        Registry::registerAiDriver('shared_name', $this->aiMeta());
 
         $this->assertSame('RateDriver', Registry::driverMeta('exchange_rate', 'shared_name')['class']);
-        $this->assertSame('AiDriver', Registry::driverMeta('ai', 'shared_name')['class']);
+        $this->assertSame(FakeAiDriver::class, Registry::driverMeta('ai', 'shared_name')['class']);
+    }
+
+    public function test_ai_driver_rejects_duplicate_identifiers_without_replacing_the_first_registration(): void
+    {
+        Registry::flushDrivers();
+        Registry::registerAiDriver('fake', $this->aiMeta());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('already registered');
+
+        Registry::registerAiDriver('fake', $this->aiMeta(['label' => 'replacement']));
+    }
+
+    public function test_ai_driver_registration_is_idempotent_for_identical_metadata(): void
+    {
+        Registry::flushDrivers();
+        Registry::registerAiDriver('fake', $this->aiMeta());
+        Registry::registerAiDriver('fake', $this->aiMeta());
+
+        $this->assertSame($this->aiMeta(), Registry::driverMeta('ai', 'fake'));
+    }
+
+    public function test_generic_driver_registration_remains_permissive_and_can_replace_a_driver(): void
+    {
+        Registry::flushDrivers();
+        Registry::registerDriver('pdf', 'same', ['label' => 'first']);
+        Registry::registerDriver('pdf', 'same', ['label' => 'second']);
+
+        $this->assertSame(['label' => 'second'], Registry::driverMeta('pdf', 'same'));
+    }
+
+    #[DataProvider('invalidAiDriverRegistrations')]
+    public function test_ai_driver_rejects_malformed_metadata(string $name, array $meta, string $message): void
+    {
+        Registry::flushDrivers();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        Registry::registerAiDriver($name, $meta);
+    }
+
+    /** @return iterable<string, array{string, array<string, mixed>, string}> */
+    public static function invalidAiDriverRegistrations(): iterable
+    {
+        $valid = self::validAiMeta();
+
+        yield 'blank identifier' => ['', $valid, 'stable, non-empty identifier'];
+        yield 'unstable identifier' => ['not a driver', $valid, 'stable, non-empty identifier'];
+        yield 'missing class' => ['fake', array_diff_key($valid, ['class' => true]), 'concrete class extending'];
+        yield 'non-driver class' => ['fake', array_replace($valid, ['class' => self::class]), 'concrete class extending'];
+        yield 'abstract driver class' => ['fake', array_replace($valid, ['class' => AbstractFakeAiDriver::class]), 'concrete class extending'];
+        yield 'blank label' => ['fake', array_replace($valid, ['label' => ' ']), 'label must be a non-empty string'];
+        yield 'empty roles' => ['fake', array_replace($valid, ['supported_roles' => []]), 'supported_roles must be a non-empty unique list'];
+        yield 'duplicate roles' => ['fake', array_replace($valid, ['supported_roles' => ['chat', 'chat']]), 'supported_roles must be a non-empty unique list'];
+        yield 'unsupported role' => ['fake', array_replace($valid, ['supported_roles' => ['images']]), 'supported_roles must be a non-empty unique list'];
+        yield 'non-list roles' => ['fake', array_replace($valid, ['supported_roles' => ['role' => 'chat']]), 'supported_roles must be a non-empty unique list'];
+        yield 'invalid website' => ['fake', array_replace($valid, ['website' => 1]), 'website must be a string'];
+        yield 'invalid default base URL' => ['fake', array_replace($valid, ['default_base_url' => []]), 'default_base_url must be a string'];
+        yield 'missing suggested models' => ['fake', array_diff_key($valid, ['suggested_models' => true]), 'suggested_models must be a list'];
+        yield 'non-list suggested models' => ['fake', array_replace($valid, ['suggested_models' => ['model' => ['value' => 'm', 'label' => 'M']]]), 'suggested_models must be a list'];
+        yield 'model with an empty value' => ['fake', array_replace($valid, ['suggested_models' => [['value' => '', 'label' => 'M']]]), 'non-empty string value and label'];
+        yield 'model with an unknown field' => ['fake', array_replace($valid, ['suggested_models' => [['value' => 'm', 'label' => 'M', 'id' => 'm']]]), 'non-empty string value and label'];
+        yield 'missing config fields' => ['fake', array_diff_key($valid, ['config_fields' => true]), 'config_fields must be an array'];
+        yield 'invalid config fields' => ['fake', array_replace($valid, ['config_fields' => 'not-an-array']), 'config_fields must be an array'];
+    }
+
+    /** @param array<string, mixed> $changes @return array<string, mixed> */
+    private function aiMeta(array $changes = []): array
+    {
+        return array_replace(self::validAiMeta(), $changes);
+    }
+
+    /** @return array<string, mixed> */
+    private static function validAiMeta(): array
+    {
+        return [
+            'class' => FakeAiDriver::class,
+            'label' => 'fake.ai.label',
+            'supported_roles' => ['chat', 'text_generation'],
+            'suggested_models' => [['value' => 'fake-model', 'label' => 'Fake model']],
+            'config_fields' => [],
+        ];
     }
 
     public function test_all_drivers_returns_empty_array_for_unknown_type(): void
@@ -368,3 +455,23 @@ class RegistryTest extends TestCase
         $this->assertSame([], Registry::allDrivers('exchange_rate'));
     }
 }
+
+class FakeAiDriver extends AiDriver
+{
+    public function chatCompletion(array $messages, string $model, array $tools = [], array $options = []): AiChatResponse
+    {
+        return new AiChatResponse('ok');
+    }
+
+    public function textCompletion(string $prompt, string $model, array $options = []): string
+    {
+        return 'ok';
+    }
+
+    public function validateConnection(): array
+    {
+        return [];
+    }
+}
+
+abstract class AbstractFakeAiDriver extends AiDriver {}


### PR DESCRIPTION
Extracts the provider-neutral AI ABI and host boundaries required by the optional AI Assistant module.

- adds AI driver, response, and exception contracts
- validates AI driver registrations
- adds settings, authorization, and company data reader host contracts
- publishes the typed frontend extension API
- advances generated modules to module API 1.2 / SDK 3.3
- updates the module release runtime to PHP 8.4 and Node 24

Tests: `composer test` (128 tests, 338 assertions); `composer lint`