### PR TITLE
docs: refresh Module SDK guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,170 +1,126 @@
-# InvoiceShelf Modules
+# InvoiceShelf Modules SDK
 
-The MIT-licensed SDK for InvoiceShelf v3 modules. It extends [`nwidart/laravel-modules`](https://github.com/nWidart/laravel-modules) with registry helpers and the versioned, signed marketplace contract used by the secure module installer.
+The MIT-licensed SDK for official [InvoiceShelf](https://invoiceshelf.com) v3 modules. It extends [`nwidart/laravel-modules`](https://github.com/nWidart/laravel-modules) with the contracts used by InvoiceShelf's module host and signed marketplace packages.
 
-The SDK remains MIT. Official first-party modules are separate repositories and packages, and must be licensed `AGPL-3.0-only`; the generator's `composer.json` stub defaults to that license.
+SDK **3.3** supports Module API **1.2**. First-party module packages live in their own repositories and are licensed `AGPL-3.0-only`; this SDK remains MIT.
 
-## What it provides
+## What a module can add
 
-- **`InvoiceShelf\Modules\Registry`** — a static registry that modules call from their `ServiceProvider::boot()` to declare:
-  - A sidebar entry (title, link, icon) that the host app renders in the company sidebar's "Modules" group.
-  - A settings schema (sections of typed fields) that the host app renders generically as a form via `BaseSchemaForm.vue`, with values stored per-company.
-- **`InvoiceShelf\Modules\Settings\Schema` / `FieldType`** — a value object + enum that lock down the supported field types (`text`, `password`, `textarea`, `switch`, `number`, `select`, `multiselect`) and validate the schema shape at registration time.
-- **`InvoiceShelf\Modules\Ai`** — framework-neutral AI provider contracts for module drivers: extend `Ai\Contracts\AiDriver`, return `Ai\Data\AiChatResponse` from chat completions, and throw `Ai\Exceptions\AiException` for provider failures.
-- **`InvoiceShelf\Modules\Contracts\Host`** — host boundaries for global/company settings, company-scoped authorization, and the AI assistant's twelve read-only company-data queries. These expose only scalar values and arrays, never Laravel or application models.
-- **`frontend/index.d.ts`** — the versioned TypeScript contract for module-contributed UI surfaces, authenticated HTTP access, translations, notifications, and host lifecycle events. Module builds consume it as a type-only dependency from the Composer-installed SDK.
+- Sidebar entries and schema-driven, per-company settings.
+- Local, compiled JavaScript and CSS registered with the host.
+- Typed frontend contributions through [`frontend/index.d.ts`](frontend/index.d.ts): routes, menus, HTTP access, translations, notifications, and lifecycle events. The host supplies the Vue, router, Axios, and i18n instances—modules do not bundle another framework runtime.
+- Narrow host contracts under [`src/Contracts/Host`](src/Contracts/Host) for settings, authorization, and the AI assistant's read-only company-data queries. Module code must not depend on InvoiceShelf Eloquent models.
+- AI drivers through [`src/Ai`](src/Ai): extend `AiDriver`, return `AiChatResponse`, and throw `AiException` for safe, localizable provider failures.
 
-The actual module loading, file generation, migration, and provider registration are all handled by upstream `nwidart/laravel-modules` (required as a composer dependency).
+The host controls discovery, installation, activation, migrations, and provider registration. Official packages are not a general-purpose runtime Composer installer for arbitrary third-party code.
 
-## Official module package contract
+## Compatibility
 
-An official module lives in its own repository and Composer package — never in this SDK repository or in the InvoiceShelf application repository. First-party packages use the reserved `invoiceshelf/module-<slug>` convention (the generator's Composer stub uses it automatically); this marketplace contract is for official modules, not a runtime package-install mechanism for arbitrary third-party code. `php artisan module:make` creates the extended `module.json` automatically through this SDK's [`stubs/json.stub`](stubs/json.stub).
+Declare compatibility in `module.json`, then test it against the host versions you support.
 
-`module.json` is schema version 2. Its identity (`slug`, loader `name`) is immutable after the first marketplace release. It preserves nwidart loader keys (`name`, `alias`, `description`, `keywords`, `priority`, `providers`, `aliases`, `files`, and `requires`) and adds an exact SemVer `version`, SPDX `license`, compatibility constraints, required `ext-*` PHP extensions, module-to-module SemVer dependencies, local compiled `dist/*.js`/`dist/*.css` assets, and a required uninstall cleanup class. Unknown fields beyond those defined loader and SDK keys are rejected. The SDK continues to parse schema-v1 manifests as legacy forward-only packages; new modules must use schema v2.
+| Concern | Current contract |
+| --- | --- |
+| SDK | `invoiceshelf/modules` `^3.3` |
+| Module API | `^1.2.0` |
+| Host application | Your explicit InvoiceShelf 3.x range |
+| PHP | The range your module actually supports |
+
+Composer caret constraints do **not** include prereleases. For example, `^3.0.0` starts at the final `3.0.0`, so it excludes `3.0.0-alpha.*`. A module intended for the current v3 preview must explicitly opt in, for example:
+
+```json
+"invoiceshelf": ">=3.0.0-alpha.2 <4.0.0"
+```
+
+Use `^3.0.0` only when you mean final 3.x releases. The generated stub is a starting point; update its PHP and InvoiceShelf constraints before releasing.
+
+## Module manifest and lifecycle
+
+New official modules use schema version 2. Their identity is permanent after the first marketplace release: keep `slug` and loader `name` unchanged. The manifest also declares an exact SemVer version, license, compatibility, required PHP extensions, module dependencies, local assets, and uninstall behavior.
 
 ```json
 {
   "schema_version": 2,
-  "slug": "sales-tax-us",
   "name": "SalesTaxUs",
   "alias": "salestaxus",
-  "description": "",
-  "keywords": [],
-  "priority": 0,
+  "slug": "sales-tax-us",
   "version": "1.2.3",
   "license": "AGPL-3.0-only",
-  "providers": ["Modules\\SalesTaxUs\\Providers\\SalesTaxUsServiceProvider"],
-  "aliases": {},
-  "files": [],
-  "requires": {},
+  "providers": [
+    "Modules\\SalesTaxUs\\Providers\\SalesTaxUsServiceProvider"
+  ],
   "compatibility": {
-    "invoiceshelf": "^3.0.0",
+    "invoiceshelf": ">=3.0.0-alpha.2 <4.0.0",
     "module_api": "^1.2.0",
-    "php": "^8.3.0",
+    "php": "^8.4.0",
     "extensions": ["ext-json"]
   },
-  "module_dependencies": {"accounting-core": "^1.0.0"},
   "migration_policy": "reversible",
   "dependency_policy": "host-provided-only",
   "uninstall": {
-    "data_cleanup": "Modules\\SalesTaxUs\\Providers\\SalesTaxUsServiceProvider"
+    "data_cleanup": "Modules\\SalesTaxUs\\Lifecycle\\DataCleanup"
   },
   "assets": ["dist/module.js", "dist/module.css"]
 }
 ```
 
-The policies are deliberately closed: schema-v2 migrations are reversible and installation never runs Composer, npm, pnpm, or another dependency resolver. Every PHP migration under `database/migrations` (or legacy `Database/Migrations`) must contain exactly one concrete class extending Laravel's `Migration`, with public, non-static, zero-argument, non-empty `up(): void` and `down(): void` methods. The package validator parses those files as PHP ASTs: destructive calls (including `drop*`, `rename*`, `update*`, `raw`, `unprepared`, `statement`, `affectingStatement`, `delete`, and `truncate`) are forbidden in `up()` and allowed in `down()`. Runtime dependencies must be provided by InvoiceShelf (`host-provided-only`). Generated packages use Orchestra Testbench 11 (Laravel 13), PHPUnit 12, and Pint only as `require-dev` CI tooling; build tooling is allowed in CI only, and compiled output is shipped inside the ZIP. Remote URLs, source assets, path traversal, arbitrary PHP providers, unsupported constraints, and unknown manifest fields are rejected.
+Schema-v2 migrations must be reversible. Each migration has one concrete Laravel `Migration` class with non-empty `up(): void` and `down(): void` methods. The package validator rejects destructive operations in `up()` and runs no dependency resolver at installation time, so commit the local compiled assets declared in `assets`.
 
-Schema-v2 manifests must declare `uninstall.data_cleanup` as a class in their own `Modules\\<Name>\\...` namespace. That class must implement `InvoiceShelf\\Modules\\Contracts\\DataCleanup`:
+When an administrator chooses **Remove module data**, the host calls the module's cleanup hook while its tables still exist, runs every migration's `down()`, and removes host-owned module settings. Point `uninstall.data_cleanup` at a concrete, idempotent module-owned class:
 
 ```php
-use InvoiceShelf\Modules\Contracts\DataCleanup;
+<?php
 
-final class SalesTaxUsCleanup implements DataCleanup
+namespace Modules\SalesTaxUs\Lifecycle;
+
+use InvoiceShelf\Modules\Contracts\DataCleanup as DataCleanupContract;
+
+final class DataCleanup implements DataCleanupContract
 {
     public function cleanup(): void
     {
-        // Delete module-owned external resources or data outside down() migrations.
+        // Delete module-owned files, external resources, or shared-table rows.
     }
 }
 ```
 
-`cleanup()` must be idempotent because uninstall may be retried; an exception signals failure and must stop the uninstall. Its body may intentionally be empty for a no-op cleanup, but its class must be concrete and its method must be a non-static, non-abstract, zero-argument public `cleanup(): void` implementation. During uninstall, the host calls this developer cleanup first while module tables still exist, then runs every migration's `down()` method, and finally removes host-owned module settings. The scaffold uses its generated service provider as the default cleanup class purely for convenience. Modules may instead point `uninstall.data_cleanup` to a dedicated class in their own namespace.
+An intentionally empty method is valid for a module with nothing beyond reversible migrations. Throwing from `cleanup()` stops the uninstall so it can be retried safely.
 
-At runtime, `Registry::registerScript()` and `Registry::registerStyle()` accept only existing local `.js` and `.css` files (for example `module_path($name, 'dist/module.js')`). The registry stores the canonical real path and rejects URLs, missing files, and incorrect extensions; modules cannot inject remote scripts or styles.
+## Developing a module
 
-## AI module contracts
-
-AI drivers are SDK contracts, not `App\Platform` contracts. A module driver extends `InvoiceShelf\Modules\Ai\Contracts\AiDriver`; its constructor receives an API key and provider configuration, it implements chat completion, text completion, and connection validation, and it may override `listModels()`. Chat completions return `InvoiceShelf\Modules\Ai\Data\AiChatResponse`; provider failures use `InvoiceShelf\Modules\Ai\Exceptions\AiException`, whose `errorKey` is safe for the host UI to localize.
-
-Register a driver with `Registry::registerAiDriver()`. The identifier is stable and unique among AI drivers. Metadata requires a concrete SDK `AiDriver` class, a non-empty label, a non-empty unique `supported_roles` list (`chat` and/or `text_generation`), a list of `{value, label}` suggested models, and a `config_fields` array. `website` and `default_base_url` are optional strings. Generic `registerDriver()` retains its existing permissive behavior for non-AI driver categories.
-
-Modules that need host data depend on the narrow interfaces under `InvoiceShelf\Modules\Contracts\Host`: `SettingsStore` has global and per-company get/put/delete operations plus a cleanup-only operation that removes one key from every company, `ModuleAuthorization` evaluates a user/company ability against the stable `customer`, `invoice`, `expense`, `payment`, or `item` resource string (or `null` for dashboard-like abilities), and `CompanyDataReader` covers the assistant's twelve current read-only query use cases. The host owns the implementations and binds them; modules must not import application models or Laravel collections through these interfaces.
-
-Frontend modules import `InvoiceShelfExtensionApi` and its contribution types from the Composer-installed `frontend/index.d.ts` as a type-only build dependency. The host passes that API as the third argument to `window.InvoiceShelf.booting()`. Runtime contributions remain on the host's Vue, router, Axios, i18n, and notification instances; the declaration file does not bundle a second frontend framework runtime.
-
-## Signed releases
-
-Each release has a second, immutable schema-v1 `release-manifest.json`, generated in CI. It contains the module identity/version, `channel` (`stable` or `insider`), immutable `publication: "published"`, compatibility, artifact lowercase SHA-256 and byte size, `key_id`, lowercase 40-character source commit, and RFC 3339 release time. Stable releases require a final SemVer; insider releases require a prerelease SemVer.
-
-The signature is a standard-base64 Ed25519 detached signature over the canonical JSON bytes of this manifest only. Canonical JSON recursively sorts object keys lexicographically, preserves list order, uses `JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR`, and contains no whitespace or newline. The SDK verifies signatures using public keys only; it never accepts or stores private signing keys.
-
-Marketplace responses have this envelope:
-
-```json
-{
-  "success": true,
-  "manifest": { "...": "signed release manifest" },
-  "signature": "base64 detached Ed25519 signature",
-  "key_id": "official-2026-01",
-  "artifact": {
-    "sha256": "lowercase hex SHA-256",
-    "bytes": 1234,
-    "download_url": "https://...",
-    "expires_at": "2026-08-05T12:00:00Z"
-  }
-}
-```
-
-The envelope `key_id`, artifact SHA-256, and bytes must equal their signed manifest counterparts. Current catalog state is intentionally outside the signature: an optional `release_state` (`published` or `yanked`) and required `yanked_reason` for yanked releases let the marketplace yank a release without a private key or a re-sign.
-
-Use the bundled executable in development and CI:
+Install the SDK in the module project, then use Laravel Modules as usual:
 
 ```bash
-vendor/bin/invoiceshelf-module validate-module module.json
-vendor/bin/invoiceshelf-module validate-package .
-vendor/bin/invoiceshelf-module validate-release release-manifest.json
-vendor/bin/invoiceshelf-module canonicalize-release release-manifest.json > release-manifest.canonical.json
-vendor/bin/invoiceshelf-module generate-keypair official-2026-01
+composer require invoiceshelf/modules:^3.3
+php artisan module:make SalesTaxUs
 ```
 
-## Release workflow
-
-Copy or call [`.github/workflows/module-release.yml`](.github/workflows/module-release.yml) from each official module repository. When a caller invokes it from a tag, the workflow fails before secrets are used unless `GITHUB_REF_NAME` exactly equals `module.json`'s version (for example, `1.2.3`, not `v1.2.3`). Manual dispatch and branch-based `workflow_call` usage remain available. It installs dependencies, runs Pint in test mode and PHPUnit, builds frontend assets if present, validates the complete package (including built local assets and Composer host-only dependencies), makes a timestamp-normalized deterministic ZIP rooted at the module `name`, calculates SHA-256/bytes, creates and validates the release manifest, canonicalizes through the SDK CLI, then signs those exact bytes with a protected environment secret before uploading to the configured website ingest endpoint.
-
-Configure the protected `module-release` environment with:
-
-- `MODULE_SIGNING_SECRET_KEY_B64` secret: standard base64 raw Ed25519 secret key.
-- `MODULE_MARKETPLACE_INGEST_TOKEN` secret: ingest bearer token.
-- `MODULE_SIGNING_KEY_ID` variable: matching public-key identifier.
-- `MODULE_MARKETPLACE_INGEST_URL` variable: website ingest base URL ending in `/api/marketplace/v1/modules` (the workflow appends `/{slug}/releases`).
-
-No private key, token, endpoint, or organization-specific value is hardcoded in the template. The checkout disables persisted GitHub credentials; the protected, repository-scoped ingest token is used only as a masked bearer value for the single release registration request. The workflow sends the manifest and detached signature as scalar multipart fields (not upload parts), as required by the website ingest endpoint. A caller can use the workflow with `secrets: inherit`; the source repository retains the protected environment and its secrets.
-
-`generate-keypair` prints a standard-base64 Ed25519 keypair and does not write files. Put `secret_key_b64` only in the protected `MODULE_SIGNING_SECRET_KEY_B64` GitHub environment secret, put `public_key_b64` under its `key_id` in the website and InvoiceShelf public-key configuration, then discard the command output. Never commit either key.
-
-## Usage from inside a module
+Register server-side contributions from the module service provider:
 
 ```php
 use InvoiceShelf\Modules\Registry;
 
-class SalesTaxUsServiceProvider extends ServiceProvider
-{
-    public function boot(): void
-    {
-        Registry::registerMenu('sales-tax-us', [
-            'title' => 'sales_tax_us::menu.title',
-            'link'  => '/admin/modules/sales-tax-us/settings',
-            'icon'  => 'CalculatorIcon',
-        ]);
-
-        Registry::registerSettings('sales-tax-us', [
-            'sections' => [
-                [
-                    'title'  => 'sales_tax_us::settings.connection',
-                    'fields' => [
-                        ['key' => 'api_key', 'type' => 'password', 'rules' => ['required']],
-                        ['key' => 'sandbox', 'type' => 'switch',   'default' => false],
-                    ],
-                ],
-            ],
-        ]);
-    }
-}
+Registry::registerMenu('sales-tax-us', [
+    'title' => 'sales_tax_us::menu.title',
+    'link' => '/admin/modules/sales-tax-us/settings',
+    'icon' => 'CalculatorIcon',
+]);
 ```
 
-Because `nwidart/laravel-modules` only boots providers for currently-activated modules, the registry naturally only contains active modules at request time — no extra filtering needed.
+Validate both the manifest and the distributable package before every release:
+
+```bash
+vendor/bin/invoiceshelf-module validate-module module.json
+vendor/bin/invoiceshelf-module validate-package .
+```
+
+`validate-package` checks the manifest, providers, migrations, declared assets, and the closed host-provided dependency policy. The CLI also validates and canonicalizes generated `release-manifest.json` files.
+
+## Releasing an official module
+
+Every release is a deterministic signed ZIP, built in CI from an exact, unprefixed SemVer tag matching `module.json` (for example, `1.2.3`). The reusable workflow validates source and compiled assets, creates the package and signed release manifest, then registers it with the InvoiceShelf marketplace.
+
+See [RELEASING.md](RELEASING.md) for the protected GitHub environment configuration and release workflow details. Never commit a signing key or marketplace token.
 
 ## License
 
-This SDK is MIT. See [LICENSE.md](LICENSE.md). Official module packages generated from its stubs are `AGPL-3.0-only` by default and must include their corresponding license text and complete source needed to produce every shipped `dist/` asset.
+This SDK is MIT-licensed; see [LICENSE.md](LICENSE.md). Official packages generated from its stubs default to `AGPL-3.0-only` and must include the source required to reproduce every shipped `dist/` asset.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,59 @@
+# Releasing an official InvoiceShelf module
+
+This document is for maintainers of official module repositories. It describes the reusable [module release workflow](.github/workflows/module-release.yml) shipped by the SDK.
+
+## Before tagging
+
+1. Set `module.json`'s `version` to the intended exact SemVer version.
+2. Build and commit every declared `dist/` asset.
+3. Run the module's lint, tests, frontend build, and package validation.
+4. Merge the release change, then create an **unprefixed** tag that exactly matches `module.json`, for example `1.2.3` rather than `v1.2.3`.
+
+The reusable workflow rejects a tag that does not exactly match the manifest version. Stable releases require final SemVer; insider releases require a prerelease SemVer.
+
+## Use the reusable workflow
+
+An official module normally calls the tagged SDK workflow from its own tag workflow:
+
+```yaml
+jobs:
+  release:
+    uses: InvoiceShelf/modules/.github/workflows/module-release.yml@3.3.0
+    with:
+      channel: stable
+    secrets: inherit
+```
+
+The workflow installs dependencies, runs Pint and PHPUnit, builds frontend assets when present, validates the package, creates a timestamp-normalized ZIP, generates and validates `release-manifest.json`, signs its canonical JSON, and sends it to marketplace ingest.
+
+## Protected `module-release` environment
+
+Configure this protected GitHub environment in every official module repository:
+
+| Setting | Type | Purpose |
+| --- | --- | --- |
+| `MODULE_SIGNING_SECRET_KEY_B64` | Secret | Standard-base64 raw Ed25519 secret key. |
+| `MODULE_MARKETPLACE_INGEST_TOKEN` | Secret | Bearer token for the module's marketplace ingest request. |
+| `MODULE_SIGNING_KEY_ID` | Variable | Identifier of the matching public signing key. |
+| `MODULE_MARKETPLACE_INGEST_URL` | Variable | HTTPS ingest base URL ending in `/api/marketplace/v1/modules`. |
+
+The workflow appends `/{slug}/releases` to the ingest URL. It disables persisted checkout credentials and uses the protected token only for that request.
+
+Generate an Ed25519 keypair with:
+
+```bash
+vendor/bin/invoiceshelf-module generate-keypair official-2026-01
+```
+
+Put `secret_key_b64` only in the environment secret. Configure `public_key_b64` under the same `key_id` in the InvoiceShelf and marketplace public-key configuration, then discard the command output. Do not commit either key, the ingest token, or an organization-specific endpoint.
+
+## Signed release manifests
+
+CI creates an immutable schema-v1 `release-manifest.json` containing the module identity/version, channel, compatibility, artifact SHA-256 and size, signing key ID, source commit, and release time. It signs canonical JSON with an Ed25519 detached signature.
+
+The marketplace can mark a published release as yanked without re-signing it; package identity and artifact integrity remain signed. Use the SDK CLI to inspect a manifest locally:
+
+```bash
+vendor/bin/invoiceshelf-module validate-release release-manifest.json
+vendor/bin/invoiceshelf-module canonicalize-release release-manifest.json > release-manifest.canonical.json
+```


### PR DESCRIPTION
## Summary

- recast the README around SDK 3.3 and Module API 1.2 capabilities and host boundaries
- explain prerelease SemVer compatibility so preview modules do not accidentally exclude InvoiceShelf alpha releases
- document the reversible migration and developer cleanup lifecycle with an accurate dedicated cleanup class
- move protected signing and marketplace release operations into `RELEASING.md`

## Validation

- `composer run lint`
- 128 PHPUnit tests
- Markdown and external-link checks
- `git diff --check`